### PR TITLE
refactor: deduplicate Result callable constructors (Result side of #4)

### DIFF
--- a/decisions/issue-4-dedup-result-constructors.md
+++ b/decisions/issue-4-dedup-result-constructors.md
@@ -1,0 +1,23 @@
+# Entscheidungs-Log — Issue #4 (Dedup der Result-Konstruktoren)
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default (laziest funktionierend).
+
+## E1 — Scope: nur die Result-Seite statt aller vier Konstruktoren
+- **Offener Punkt:** Issue #4 nennt vier „callable constructors"; soll dieser PR alle vier dedupen?
+- **Entscheidung:** Nur `Result.as_result` → delegiert an `Result.from_fn`. `Option.from_fn`/`Option.as_option` bleiben unangetastet.
+- **Begründung:** Maintainer-Re-Scoping + Konvention „ein Anliegen pro PR". Die Option-Seite liefert die `Option`-Neufassung in #7. Parallele PRs müssen disjunkt bleiben, sonst Merge-Konflikt im selben Klassenbereich.
+- **Verworfen:** Alle vier hier dedupen — würde mit #7s Rewrite von `Option` kollidieren.
+
+## E2 — Testplatzierung der „kein Verhaltenswechsel"-Garantie
+- **Offener Punkt:** Wie absichern, dass die Delegation nichts ändert?
+- **Entscheidung:** Bestehenden `test_as_result` um eine Metadaten-Assertion (`__name__`/`__doc__`) erweitern.
+- **Begründung:** Konvention (`CLAUDE.md`, Abschnitt *Tests*): Fälle zu bestehenden parametrisierten Tabellen hinzufügen statt Einzeltests. `functools.wraps` ist der einzige Bruchpunkt der Delegation, daher genau dort der Anker.
+- **Verworfen:** Neue eigenständige Testfunktion.
+
+## E3 — `CONTEXT.md` bleibt unverändert
+- **Offener Punkt:** Muss das Glossar angepasst werden?
+- **Entscheidung:** Nein.
+- **Begründung:** Verhalten ist identisch; der Eintrag `as_result / from_fn` bleibt korrekt. Code ist Source of Truth, die Doku folgt nur bei Vertrags-/Verhaltensänderung (`CLAUDE.md`-Sync-Regel).
+- **Verworfen:** Glossar „vorsorglich" anfassen (Scope-Creep, widerspricht ponytail).

--- a/src/results/results.py
+++ b/src/results/results.py
@@ -40,14 +40,10 @@ class Result[T, E](abc.ABC):
         >>> assert div(10, 0).map_err(str) == Result.Err("division by zero")
         """
 
+        # ponytail: from_fn is the single source of the catch rule
         @functools.wraps(fn)
         def inner(*args: P.args, **kwargs: P.kwargs) -> Result[T, Exception]:
-            try:
-                result = fn(*args, **kwargs)
-            except Exception as exc:
-                return Err(exc)
-            else:
-                return Ok(result)
+            return Result.from_fn(fn, *args, **kwargs)
 
         return inner
 

--- a/tests/results/test_result.py
+++ b/tests/results/test_result.py
@@ -416,10 +416,14 @@ def test_unwrap_or_else(result, func, expected):
 def test_as_result() -> None:
     @Result.as_result
     def div(a: int, b: int) -> float:
+        """Divide a by b."""
         return a / b
 
     assert div(10, 2) == Ok(5.0)
     assert div(10, 0).map_err(str) == Err("division by zero")
+    # functools.wraps metadata is preserved by the decorator.
+    assert div.__name__ == "div"
+    assert div.__doc__ == "Divide a by b."
 
 
 def test_from_fn() -> None:


### PR DESCRIPTION
## What

Collapse `Result.as_result`'s inner function to delegate to `Result.from_fn`, so the `try/except Exception -> Err / else -> Ok` catch rule is defined in exactly one place (`from_fn`). `functools.wraps(fn)` is retained, so the decorated function keeps its `__name__`/`__doc__` and returns the same `Ok`/`Err` values as before.

## Scope

`Refs #4 (Result side; the Option-side dedup is delivered by #7)`

Per the maintainer's re-scoping, this PR implements **only the Result side**. Untouched (by design): `Option.from_fn` / `Option.as_option` (→ #7), `OptionError` / `TransposeError` (→ #5), any `__ne__` (→ #6). CONTEXT.md is unchanged — behavior is identical, so the `as_result` / `from_fn` glossary entry stays accurate.

## Behavior

No behavior change. Net diff is -1 line of logic plus a metadata-preservation assertion. `test_as_result` now also asserts `div.__name__ == "div"` and `div.__doc__` is preserved — a Green anchor that would fail if the refactor dropped `functools.wraps`.

## Verification

- `uv run pytest` — 132 passed
- `uv run ruff check` / `ruff format --check` — clean
- `uv run mypy src tests` — 6 errors, all **pre-existing** on `main` and outside the changed region (Option-side typing + untouched test files); this change adds zero new errors.

## Review findings deliberately left

None. Self-review (the `thermo-nuclear-code-quality-review` skill is C#/.NET-scoped, so the rigorous self-review fallback was used) found no real regressions; the delegation is marked `# ponytail:` as the single source of the catch rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)