### PR TITLE
refactor: remove dead Option error hierarchy (OptionError, TransposeError)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ __Cross-conversions__ tie the two families together: `Result.ok()` / `Result.err
 
 __Constructors from callables__: `Result.as_result` (decorator) and `Result.from_fn` wrap exception-raising functions (catching `Exception` into `Err`); `Option.as_option` (decorator) and `Option.from_fn` wrap `None`-returning functions into `Some`/`Null`.
 
-__Failure mode__: unwrap-style failures raise `UnwrapFailedError` (subclass of `ResultError`); `Option`/transpose errors derive from `OptionError` / `TransposeError`. `Err.unwrap()` chains the original exception via `raise ... from` when the inner value is a `BaseException`.
+__Failure mode__: unwrap-style failures raise `UnwrapFailedError` (subclass of `ResultError`) — including `Option.expect`/`Option.unwrap`, which use this Result-side class. `Err.unwrap()` chains the original exception via `raise ... from` when the inner value is a `BaseException`.
 
 __Pattern matching__ relies on `__match_args__`: match `Ok`/`Err` on their inner value (`case Ok(v)`), and match `Option` on its content (`case Option(value)` / `case Option(None)`).
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,7 +28,7 @@ Bewusst **nicht** Teil dieses Scopes:
   nicht geworfen, sondern ein `Err`/`Null` weitergereicht.
 - **Kein vollständiger Port der Rust-API.** Es existiert nur eine bewusst kleine
   Methodenauswahl. Insbesondere gibt es **kein** `unwrap_or_default` und **kein**
-  `flatten`/`zip`, und `TransposeError` wird nirgendwo geworfen.
+  `flatten`/`zip`.
 - **Keine Go-artigen `(value, error)`-Tupel.** Ein Ergebnis ist immer ein einzelnes
   Objekt eines der beiden Typ-Familien, nie ein Paar.
 
@@ -190,8 +190,8 @@ in ein `Result` **eines** `Option`:
 - `Some(Err(e))` → `Err(e)`
 - nicht-`Result`-Inhalt → `Ok(self)` (unverändert eingepackt)
 
-*Avoid:* an eine Matrix-Transposition oder an `TransposeError` denken — `transpose`
-wirft nie und meint ausschließlich das Tauschen der beiden Schachtelungs-Ebenen.
+*Avoid:* an eine Matrix-Transposition denken — `transpose` wirft nie und meint
+ausschließlich das Tauschen der beiden Schachtelungs-Ebenen.
 
 ### as_result / from_fn
 
@@ -232,27 +232,10 @@ Wert); `ResultError` ist eine **geworfene Ausnahme**.
 Bibliothek: ausgelöst von fehlgeschlagenem `unwrap`/`expect`/`unwrap_err`/`expect_err`
 — sowohl auf `Result` als auch auf `Option`.
 
-- Invariante: Auch `Option.unwrap` wirft diese **Result-seitige** Klasse, nicht
-  einen `OptionError`.
+- Invariante: Auch `Option.unwrap` wirft diese **Result-seitige** Klasse; es gibt
+  keine eigene Option-seitige Fehlerklasse.
 
 *Avoid:* eine eigene „OptionUnwrapError" erwarten — es gibt nur diese eine.
-
-### OptionError
-
-Wurzel der Option-seitigen Fehlerhierarchie (`Exception`-Subklasse). Wird nie direkt
-geworfen.
-
-*Avoid:* `OptionError` als Oberklasse von `UnwrapFailedError` annehmen — letztere
-hängt unter `ResultError`, nicht unter `OptionError`.
-
-### TransposeError
-
-`OptionError`-Subklasse, deklariert für gescheiterte `transpose`-Aufrufe. Aktuell
-**toter Begriff**: `transpose` gibt in allen Fällen ein `Ok` zurück und wirft diese
-Ausnahme nirgends.
-
-*Avoid:* `try`/`except TransposeError` um `transpose` schreiben — der Block fängt nie
-etwas. Der Begriff existiert als reserviertes Vokabular, nicht als Laufzeitverhalten.
 
 ## Beispieldialog
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library provides a robust mechanism for handling operations that can result
 - **Comprehensive API**: Methods for checking, transforming, and retrieving contained values or errors.
 - **Functional Programming Friendly**: Supports `map`, `map_err`, `and_then`, and more to work with results without explicit error checking.
 - **Option Type**: Provides `Some` and `Null` to handle optional values, similar to `Option` in Rust.
-- **Error Handling**: Custom exceptions like `UnwrapFailedError` and `TransposeError` for robust error management.
+- **Error Handling**: Custom exceptions like `UnwrapFailedError` for robust error management.
 
 ## Classes and Methods
 
@@ -71,8 +71,6 @@ This library provides a robust mechanism for handling operations that can result
 
 - **ResultError**: Base class for result-related errors.
 - **UnwrapFailedError**: Raised when an unwrap operation fails.
-- **OptionError**: Base class for option-related errors.
-- **TransposeError**: Raised when a transpose operation fails.
 
 ## Project Structure
 

--- a/decisions/issue-5-remove-dead-option-errors.md
+++ b/decisions/issue-5-remove-dead-option-errors.md
@@ -1,0 +1,28 @@
+# Entscheidungs-Log — Issue #5 (Tote Option-Fehlerhierarchie entfernen)
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default.
+
+## E1 — Löschen statt „`TransposeError` real machen"
+- **Offener Punkt:** Issue #5 bietet zwei Wege: tote Hierarchie löschen ODER `TransposeError` tatsächlich in `Option.transpose` werfen.
+- **Entscheidung:** Löschen (`OptionError` und `TransposeError` entfernt).
+- **Begründung:** (3) Rust-`Option::transpose` wirft keine dedizierte Transpose-Ausnahme — es liefert immer ein `Result`. (4) ponytail: Löschen vor Hinzufügen. Die Klassen sind nachweislich tot (`grep`: kein `raise` irgendwo). `CONTEXT.md` hält `TransposeError` bereits als „toten Begriff" fest.
+- **Verworfen:** `TransposeError` in den `case _`-Zweig von `transpose` einbauen — fügt nicht angefordertes Verhalten hinzu und weicht von Rust ab.
+
+## E2 — README Zeile 11 (Feature-Liste)
+- **Offener Punkt:** Nur `TransposeError` streichen oder den ganzen „Error Handling"-Bullet umschreiben?
+- **Entscheidung:** Nur die `TransposeError`-Referenz entfernen, `UnwrapFailedError` behalten.
+- **Begründung:** `UnwrapFailedError` ist laut `CONTEXT.md` „die einzige tatsächlich geworfene Ausnahme" der Bibliothek — der Bullet bleibt damit wahr.
+- **Verworfen:** Ganzen Bullet löschen (würde eine korrekte Aussage mitentfernen).
+
+## E3 — Reichweite der `CONTEXT.md`-Bereinigung
+- **Offener Punkt:** Neben den beiden Glossar-Einträgen referenzieren auch die Einträge `transpose` und `UnwrapFailedError` die gelöschten Klassen.
+- **Entscheidung:** Diese hängenden Erwähnungen ebenfalls bereinigt — innerhalb der „Fehlerhierarchie"-Ownership von #5. Die Verhaltens-Bullets des `transpose`-Eintrags bleiben unangetastet (Grenze zu #7 gewahrt).
+- **Begründung:** Vollständigkeit/Konvention: das Glossar darf keine nicht mehr existierenden Typen benennen (Code = Source of Truth).
+- **Verworfen:** Nur die zwei Haupteinträge entfernen und hängende Referenzen stehen lassen.
+
+## E4 — Breaking Change explizit machen
+- **Offener Punkt:** Stillschweigend entfernen oder kennzeichnen?
+- **Entscheidung:** Entfernen exportierter Namen (`OptionError`, `TransposeError`) als Breaking Change im PR-Body für Release Notes vermerkt.
+- **Begründung:** Konvention: Eingriffe in die öffentliche API werden für Konsumenten sichtbar dokumentiert.

--- a/src/results/__init__.py
+++ b/src/results/__init__.py
@@ -3,11 +3,9 @@ from .results import (
     Null,
     Ok,
     Option,
-    OptionError,
     Result,
     ResultError,
     Some,
-    TransposeError,
     UnwrapFailedError,
 )
 
@@ -16,10 +14,8 @@ __all__ = [
     "Null",
     "Ok",
     "Option",
-    "OptionError",
     "Result",
     "ResultError",
     "Some",
-    "TransposeError",
     "UnwrapFailedError",
 ]

--- a/src/results/results.py
+++ b/src/results/results.py
@@ -320,14 +320,6 @@ class Err[E](Result[Any, E]):
         return fn(self._inner_value)
 
 
-class OptionError(Exception):
-    """Base result error."""
-
-
-class TransposeError(OptionError):
-    """Transpose failed error."""
-
-
 def Some[T](value: T) -> Option[T]:
     """
     Creates an `Option` instance that contains `Some` value.

--- a/tests/results/test_option.py
+++ b/tests/results/test_option.py
@@ -468,3 +468,21 @@ def test_or_else_when_some_should_return_some(option, func, expected):
 )
 def test_transpose_with_result(option, expected):
     assert option.transpose() == expected
+
+
+@pytest.mark.parametrize(
+    "removed_name",
+    [
+        "OptionError",
+        "TransposeError",
+    ],
+    ids=[
+        "option_error_is_removed_from_public_api",
+        "transpose_error_is_removed_from_public_api",
+    ],
+)
+def test_dead_option_error_hierarchy_is_no_longer_exported(removed_name):
+    import results
+
+    assert not hasattr(results, removed_name)
+    assert removed_name not in results.__all__


### PR DESCRIPTION
Closes #5

## What

`OptionError` and `TransposeError` were declared in `src/results/results.py` and exported via the public API, but **neither is ever raised** anywhere in the library:

- `Option.transpose` always returns `Ok`/`Err` (it never raises `TransposeError`).
- `Option.expect` / `Option.unwrap` raise the Result-side `UnwrapFailedError`, not an Option-side error.

This PR deletes the dead hierarchy (the primary path from the issue) rather than wiring `TransposeError` to actually raise.

## Changes

- `src/results/results.py`: remove the `OptionError` and `TransposeError` class declarations.
- `src/results/__init__.py`: remove both names from the import block and `__all__`.
- `README.md`: drop the `TransposeError` feature mention and the `OptionError` / `TransposeError` bullets under "Error Handling".
- `CONTEXT.md`: remove the `### OptionError` and `### TransposeError` glossary entries, the "scope" clause about `TransposeError`, and trim the now-dangling class references in the `transpose` and `UnwrapFailedError` entries.
- `CLAUDE.md`: correct the "Failure mode" sentence so it no longer references the deleted classes.
- `tests/results/test_option.py`: add a parametrized test asserting both names are absent from the `results` module and from `__all__`.

## ⚠️ Breaking change

Removes the exported names **`OptionError`** and **`TransposeError`** from `results`. Any consumer doing `from results import OptionError` / `TransposeError` will break. Note for release notes.

## Verification

- `uv run pytest` — 134 passed.
- `uv run ruff check` / `uv run ruff format` — clean.
- `uv run mypy src tests` — the 6 reported errors are **pre-existing on `main`** (unchanged in number and nature; they live in `Option` typing handled by issue #7). This PR introduces no new type errors.
- Repo-wide `grep` confirms no `OptionError`/`TransposeError` references remain except the two intentional test string literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)