### PR TITLE
feat!: make Option a sealed two-state type (Some/Null) with polymorphic dispatch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,10 @@ The entire library is one module, [src/results/results.py](src/results/results.p
 
 __`Result[T, E]`__ is an `abc.ABC` with two `@final` concrete subclasses, `Ok[T]` (declared `Result[T, Any]`) and `Err[E]` (declared `Result[Any, E]`). Every method is abstract on the base and implemented on both subclasses — behavior is selected by *polymorphism*, never by `isinstance`/flag checks inside a method. When adding a method to `Result`, add the `@abc.abstractmethod` stub plus an `Ok` and an `Err` implementation.
 
-__`Option[T]`__ is a *single concrete class* (not split into subclasses). It stores `_content: T | None` and uses `None` as the "null" sentinel. `Some(value)` and `Null()` are module-level factory functions delegating to the `Option.some()` / `Option.none()` classmethods. Consequences to keep in mind:
+__`Option[T]`__ mirrors `Result`'s design: an `abc.ABC` with two `@final` concrete subclasses, `Some[T]` (value present) and `Null[T]` (value absent). Absence is encoded in the *type* — there is no stored `None` sentinel — so behavior is selected by *polymorphism*, never by `_content is None` or truthiness checks inside a method. `Some(value)` and `Null()` are the only constructors (the base ABC is not directly instantiable). When adding a method to `Option`, add the `@abc.abstractmethod` stub plus a `Some` and a `Null` implementation. Consequences to keep in mind:
 
-- `Some(None)` is indistinguishable from `Null()`.
-- `unwrap_or` / `unwrap_or_else` test truthiness (`self._content or default`), so falsy values like `0` or `""` are treated like absence.
+- `Some(None) != Null()` — present-but-`None` is a distinct, legal state.
+- `unwrap_or` / `unwrap_or_else` / `__iter__` dispatch structurally on the variant, so falsy values like `0` / `""` / `[]` are treated as *present* (e.g. `Some(0).unwrap_or(42) == 0`).
 
 __Cross-conversions__ tie the two families together: `Result.ok()` / `Result.err()` produce an `Option`; `Option.ok_or()` / `Option.ok_or_else()` produce a `Result`; `Option.transpose()` swaps an `Option[Result]` into a `Result[Option]`.
 
@@ -41,7 +41,7 @@ __Constructors from callables__: `Result.as_result` (decorator) and `Result.from
 
 __Failure mode__: unwrap-style failures raise `UnwrapFailedError` (subclass of `ResultError`); `Option`/transpose errors derive from `OptionError` / `TransposeError`. `Err.unwrap()` chains the original exception via `raise ... from` when the inner value is a `BaseException`.
 
-__Pattern matching__ relies on `__match_args__`: match `Ok`/`Err` on their inner value (`case Ok(v)`), and match `Option` on its content (`case Option(value)` / `case Option(None)`).
+__Pattern matching__ relies on `__match_args__`: match `Ok`/`Err` on their inner value (`case Ok(v)`), and match the `Option` variants directly (`case Some(v)` binds the value; `case Null()` matches the empty variant).
 
 The codebase uses PEP 695 generics throughout — `class Result[T, E]`, method-level `def map[U](...)`, and ParamSpec via `[**P]`. Preserve this style rather than reverting to `TypeVar`/`Generic`.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -75,41 +75,46 @@ herumgereicht, ohne selbst zu werfen — bis jemand `unwrap` aufruft.
 
 ### Option
 
-Container für einen optionalen Wert. Anders als `Result` ist `Option` **eine
-einzige konkrete Klasse** (keine Variantenpaare). Sie speichert `_content: T | None`
-und benutzt `None` als „leeres" Sentinel.
+Abstrakte Basis (`abc.ABC`) für genau zwei `@final` Varianten: `Some` (vorhanden)
+und `Null` (abwesend) — **strukturell** wie `Result`/`Ok`/`Err` modelliert. Die
+Abwesenheit steckt im **Typ** (eine eigene `Null`-Variante), nicht in einem
+gespeicherten Sentinel-Wert. Jede Methode ist auf der Basis abstrakt und auf beiden
+Varianten implementiert; welche Variante vorliegt, entscheidet die **Polymorphie**,
+nie eine `_content is None`- oder Truthiness-Abfrage im Methodenrumpf.
 
-- **None-Kollaps-Regel** (hier kanonisch definiert; andere Einträge verweisen
-  darauf, statt sie zu wiederholen): Der leere Zustand ist ausschließlich
-  `_content is None` — es gibt keinen separaten Leer-Typ. Folge: `Some(None)` ist
-  von `Null()` **nicht** unterscheidbar (`Some(None) == Null()`).
+- Invariante: `Option` selbst wird nie instanziiert (die ABC ist nicht direkt
+  konstruierbar) — eine Instanz ist immer **genau eine** der Varianten `Some` oder
+  `Null`. Weil Abwesenheit ein eigener Typ ist, ist `Some(None)` ein legaler,
+  **vorhandener** Zustand und von `Null()` unterscheidbar (`Some(None) != Null()`).
 
 *Avoid:* „`typing.Optional`", „nullable Referenz". `Option` ist ein eigenes
 Wrapper-Objekt; `Optional[T]` ist bloß `T | None` ohne Methoden.
 
 ### Some
 
-Modul-Funktion `Some(value)`, die ein `Option` mit vorhandenem Inhalt erzeugt
-(delegiert an `Option.some`).
+Die vorhandene Variante von `Option`; `@final`-Subklasse, die genau einen Wert vom
+Typ `T` hält. `Some(value)` ist ihr Konstruktor.
 
-- Invariante: `Some(v).is_some()` ist `True` — **außer** für `v is None` (dann
-  greift die None-Kollaps-Regel von `Option`).
+- Invariante: `Some(v).is_some()` ist **immer** `True` — auch für `v is None`
+  (`Some(None)` ist ein vorhandener Zustand, verschieden von `Null()`).
 
-*Avoid:* „Just" (Haskell), „present()". `Some` ist **keine** Garantie für
-Anwesenheit (siehe None-Kollaps-Regel).
+*Avoid:* „Just" (Haskell), „present()". `Some(5)` ist ein Container um `5`, nicht die
+Zahl `5` selbst.
 
 ### Null
 
-Modul-Funktion `Null()`, die ein leeres `Option` erzeugt (delegiert an
-`Option.none`, setzt `_content = None`).
+Die abwesende Variante von `Option`; `@final`-Subklasse ohne gespeicherten Wert.
+`Null()` ist ihr Konstruktor und nimmt **keine** Argumente.
 
-- Invariante: `Null().is_none()` ist `True`; nimmt **keine** Argumente (Gegenstück
-  zu `Some` unter der None-Kollaps-Regel von `Option`).
+- Invariante: `Null().is_none()` ist `True`; alle Varianten sind untereinander
+  gleich (`Null() == Null()`) und von jedem `Some(...)` verschieden — auch von
+  `Some(None)`.
 
-*Avoid:* „Pythons `None`", „Nil", „Nothing". `Null()` ist ein `Option`-Objekt, das
-ein `None` umhüllt — nicht das `None` selbst. Die in einigen Docstrings gezeigten
-Aufrufe mit Argument (`Null("Error")`, `Null(10)`) sind fehlerhaft: `Null` nimmt
-keine Parameter und würde mit `TypeError` scheitern.
+*Avoid:* „Pythons `None`", „Nil", „Nothing". `Null()` ist ein eigenständiger
+`Option`-Typ für Abwesenheit — nicht das `None` selbst und kein `Some`, das ein
+`None` umhüllt. Die in einigen Docstrings gezeigten Aufrufe mit Argument
+(`Null("Error")`, `Null(10)`) sind fehlerhaft: `Null` nimmt keine Parameter und
+würde mit `TypeError` scheitern.
 
 ### unwrap
 
@@ -131,13 +136,15 @@ Entpacken mit Rückfallwert: `unwrap_or(default)` bzw. `unwrap_or_else(fn)` lief
 den enthaltenen Wert oder einen Ersatz, ohne je zu werfen.
 
 - Invariante (`Result`): Der Rückfall greift genau bei `Err`.
-- Invariante (`Option`): Hier wird per **Wahrheitswert** entschieden
-  (`self._content or default`). Folge: Falsy-Inhalte wie `0`, `""`, `[]` liefern
-  den Rückfallwert, obwohl sie eigentlich „vorhanden" sind. Dieselbe
-  Truthiness-Logik gilt für die Iteration über ein `Option`.
+- Invariante (`Option`): Der Rückfall greift **strukturell** genau bei `Null` —
+  per Polymorphie auf der Variante, nicht per Wahrheitswert. Folge: Falsy-Inhalte
+  wie `0`, `""`, `[]` (und auch `None`) sind **vorhanden** und werden zurückgegeben;
+  `Some(0).unwrap_or(42)` ist `0`. Dieselbe strukturelle Logik gilt für die
+  Iteration über ein `Option`: `Some(0)` iteriert zu `[0]`, `Null()` zu `[None]`.
 
-*Avoid:* anzunehmen, `Option.unwrap_or` prüfe auf Anwesenheit (`is None`) — es prüft
-Truthiness. Auf der `Result`-Seite gibt es diese Falle nicht.
+*Avoid:* anzunehmen, `Option.unwrap_or` prüfe Truthiness — der alte
+`self._content or default`-Trick ist weg. Es entscheidet die Variante (`Some` vs.
+`Null`), genau wie auf der `Result`-Seite.
 
 ### map
 
@@ -173,9 +180,11 @@ Brücken zwischen den beiden Familien, die einen Typ in den anderen überführen
 - `Option.ok_or(err)` / `Option.ok_or_else(fn)` → `Result[T, E]` (`Some(v)` → `Ok(v)`,
   `Null()` → `Err(err)` bzw. `Err(fn())`).
 
-- Invariante: `ok_or`/`ok_or_else` entscheiden per `is None` (nicht per Truthiness),
-  daher bleibt `Some(0)` ein `Ok(0)`.
-- Folge der `None`-Kollaps-Regel: `Ok(None).ok()` ergibt `Some(None)`, also `Null()`.
+- Invariante: `ok_or`/`ok_or_else` entscheiden **strukturell** über die Variante
+  (`Some` vs. `Null`), nicht per Truthiness oder `is None`, daher bleibt `Some(0)`
+  ein `Ok(0)`.
+- `Ok(None).ok()` ergibt `Some(None)` — ein **vorhandenes** `Option`, das von
+  `Null()` verschieden ist (`Ok(_).ok()` ist immer ein `Some`, nie `Null()`).
 
 *Avoid:* „Cast"/„isinstance-Umwandlung". Es entsteht jeweils ein **neues** Objekt der
 Zielfamilie; das Original wird nicht verändert.
@@ -256,26 +265,27 @@ etwas. Der Begriff existiert als reserviertes Vokabular, nicht als Laufzeitverha
 
 ## Beispieldialog
 
-**1 — `Some(None)` ist nicht „vorhanden"**
+**1 — `Some(None)` ist „vorhanden", verschieden von `Null()`**
 
 > **Entwickler:** Ich packe ein optionales Ergebnis in `Some(result)`. Wenn `result`
 > mal `None` ist, behalte ich doch immer noch ein „vorhandenes" `Some`, oder?
 >
-> **Expertin:** Nein. `Option` benutzt `None` als Leer-Sentinel, deshalb kollabiert
-> `Some(None)` zu `Null()` — `Some(None) == Null()` ist `True`. Wenn „vorhanden, aber
-> None" ein gültiger Zustand sein muss, ist `Option` der falsche Typ. Für „gelungen
-> mit Wert `None`" nimm `Ok(None)`.
+> **Expertin:** Ja. `Option` ist ein versiegelter Zwei-Zustands-Typ: Abwesenheit
+> steckt im **Typ** (`Null`), nicht im Wert. `Some(None)` ist deshalb ein
+> vorhandener Zustand und von `Null()` unterscheidbar — `Some(None) == Null()` ist
+> `False`, und die `repr`s lauten `Some(None)` bzw. `Null()`. „Vorhanden, aber
+> `None`" ist hier ein gültiger, ausdrückbarer Zustand.
 
-**2 — `Option.unwrap_or` prüft Truthiness, nicht Anwesenheit**
+**2 — `Option.unwrap_or` prüft die Variante, nicht Truthiness**
 
 > **Entwickler:** Dann hole ich den Wert eben sicher mit `Some(0).unwrap_or(42)` —
 > das gibt `0` zurück.
 >
-> **Expertin:** Es gibt `42` zurück. `Option.unwrap_or` entscheidet per Wahrheitswert
-> (`self._content or default`), und `0` ist falsy. Dieselbe Falle haben `0`, `""` und
-> `[]`. Willst du nur auf Anwesenheit prüfen, nutze `ok_or` (prüft `is None`) oder
-> Pattern-Matching. Auf der `Result`-Seite tritt das nicht auf: `Ok(0).unwrap_or(42)`
-> ist `0`.
+> **Expertin:** Richtig, es gibt `0` zurück. `Option.unwrap_or` entscheidet
+> **strukturell** über die Variante (`Some` vs. `Null`), nicht per Wahrheitswert.
+> Falsy-Werte wie `0`, `""`, `[]` (und `None`) bleiben „vorhanden" und werden
+> geliefert; nur `Null()` fällt auf den Default zurück. Genau wie auf der
+> `Result`-Seite: `Ok(0).unwrap_or(42)` ist `0`.
 
 **3 — `map` vs. `and_then` (doppelte Verschachtelung)**
 

--- a/decisions/issue-7-seal-option-two-state.md
+++ b/decisions/issue-7-seal-option-two-state.md
@@ -1,0 +1,45 @@
+# Entscheidungs-Log — Issue #7 (Option als versiegelter Zwei-Zustands-Typ)
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default.
+
+## E1 — `Some`/`Null` als `@final`-Subklassen statt Factory-Funktionen
+- **Offener Punkt:** Das Issue lässt offen, ob `Some`/`Null` echte Subklassen werden oder dünne Factories bleiben, die auf Subklassen delegieren.
+- **Entscheidung:** Echte `@final`-Subklassen von `Option[T]`: `Some[T]` (trägt `_value` im Slot) und `Null[T]` (slotlos, kein Wert).
+- **Begründung:** (1) `CLAUDE.md`-Architektur — Verhalten per Polymorphie, nie per Flag/`isinstance`; exakt das `Result`/`Ok`/`Err`-Muster. (3) Rust modelliert `Some`/`None` als Varianten. Ermöglicht direktes Pattern-Matching `case Some(v)` / `case Null()`.
+- **Verworfen:** Modul-Factory-Funktionen, die an Classmethods delegieren (das Alt-Muster) — hielten einen Konstruktionspfad für den Leerzustand offen und verkomplizieren `__match_args__`.
+
+## E2 — `Option.some()` / `Option.none()` Classmethods behalten
+- **Offener Punkt:** Entfernen oder behalten?
+- **Entscheidung:** Als dünne Delegatoren an `Some`/`Null` behalten.
+- **Begründung:** (2) Bestehende öffentliche API; ponytail: minimaler Eingriff, kein zusätzlicher Bruch über den Issue-Scope hinaus.
+- **Verworfen:** Entfernen (unnötiger zweiter Breaking Change).
+
+## E3 — Direkte Konstruktion des Leerzustands verhindern
+- **Offener Punkt:** Wie „make illegal states unrepresentable" technisch umsetzen?
+- **Entscheidung:** Basis `Option` = `abc.ABC` mit abstrakten Methoden → `Option()` wirft `TypeError`; kein öffentlicher `__init__`, der `None` als Leer-Sentinel speichert.
+- **Begründung:** Issue-Kern + `CONTEXT.md`-Invariante „`Result` selbst wird nie instanziiert". Abwesenheit ist nun strukturell (eigener Typ), nicht der Wert `None`.
+- **Verworfen:** Sentinel-basierte Einzelklasse (`_MISSING`-Objekt) — inspiziert weiterhin einen gespeicherten Wert, macht Abwesenheit nicht strukturell und widerspricht der vom Issue geforderten polymorphen Dispatch-Logik.
+
+## E4 — `__match_args__`-Form
+- **Offener Punkt:** Pattern-Matching-Form unter dem neuen Design.
+- **Entscheidung:** `Some.__match_args__ = ("_value",)`, `Null.__match_args__ = ()`.
+- **Begründung:** `case Some(v)` bindet den Wert, `case Null()` matcht den Leerzustand ohne Bindung — Spiegel von Rusts `Some(v)` / `None`. Ersetzt das alte `case Option(content)` der Einzelklassen-Ära.
+- **Verworfen:** Weiter auf `_content` matchen.
+
+## E5 — `transpose`-Semantik unter den neuen Semantiken
+- **Offener Punkt:** `Null()` ist nun von `Some(None)` verschieden — ändert das `Option.transpose`?
+- **Entscheidung:** Semantik unverändert: `Null() → Ok(Null())`, `Some(Ok(v)) → Ok(Some(v))`, `Some(Err(e)) → Err(e)`, sonst `Ok(Some(_))`. Umsetzung jetzt polymorph statt per `_content`-Match.
+- **Begründung:** (3) entspricht Rust-`transpose`; (1) `CONTEXT.md` `transpose`-Eintrag (dessen Text #5/Bestand bleibt). Kein Sonderfall für `Some(None)` nötig — der Leerzustand ist ohnehin ein eigener Typ.
+- **Verworfen:** Einen Sonderzweig für `Some(None)` einführen.
+
+## E6 — Doku-Grenze zu #5
+- **Offener Punkt:** Sowohl #5 als auch #7 fassen `CONTEXT.md`/`CLAUDE.md` an.
+- **Entscheidung:** #7 ändert nur die Einträge `Option`/`Some`/`Null`/`unwrap_or`/`Cross-Conversion` + Beispieldialoge 1 & 2 bzw. die `Option`-Architektur- und Pattern-Matching-Absätze. `OptionError`/`TransposeError`/`transpose`-Einträge und der „Failure mode"-Satz bleiben #5.
+- **Begründung:** Disjunkte Zeilenbereiche → unabhängig mergebare PRs (Koordinations-Konvention).
+
+## E7 — Breaking Change kennzeichnen
+- **Offener Punkt:** Umfang der Verhaltensänderung.
+- **Entscheidung:** Major-Bump; im PR-Body als Breaking Change vermerkt: `Some(None) != Null()`, falsy-`Some(...)` nicht mehr als „abwesend" behandelt, `Option(...)` nicht mehr direkt konstruierbar.
+- **Begründung:** Konvention: sichtbare API-/Semantik-Brüche werden für Konsumenten dokumentiert.

--- a/src/results/results.py
+++ b/src/results/results.py
@@ -328,38 +328,21 @@ class TransposeError(OptionError):
     """Transpose failed error."""
 
 
-def Some[T](value: T) -> Option[T]:
+class Option[T](abc.ABC):
     """
-    Creates an `Option` instance that contains `Some` value.
-
-    Examples:
-    >>> assert Option.some(10) == Some(10)
+    `Option` is a sealed two-state type: a value is either present ([`Some`]) or
+    absent ([`Null`]). Absence is encoded in the *type* (a separate [`Null`]
+    variant), never in a stored sentinel value, so `Some(None)` is a legal,
+    present state distinct from `Null()`. Behavior is selected by polymorphic
+    dispatch on the two `@final` variants; the base class is abstract and cannot
+    be instantiated directly.
     """
-    return Option[T].some(value)
-
-
-def Null[T]() -> Option[T]:
-    """
-    Creates an `Option` instance that contains a `Null` value.
-
-    Examples:
-    >>> assert Option.null("Error") == Null("Error")
-    """
-    return Option[T].none()
-
-
-class Option[T: object]:
-    __slots__ = ("_content",)
-    __match_args__ = ("_content",)
-
-    def __init__(self, content: T | None = None) -> None:
-        self._content = content
 
     @staticmethod
     def from_fn[**P](
         fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs
     ) -> Option[T]:
-        """Turns a function so that it returns a `Option<T, N>` instead of `T | None`.
+        """Turns a function so that it returns a `Option<T>` instead of `T | None`.
 
         Caller is responsible for ensuring that the function does not raise an exception.
         # Examples:
@@ -388,27 +371,9 @@ class Option[T: object]:
 
         @functools.wraps(fn)
         def inner(*args: P.args, **kwargs: P.kwargs) -> Option[T]:
-            return Null() if (option := fn(*args, **kwargs)) is None else Some(option)
+            return Option.from_fn(fn, *args, **kwargs)
 
         return inner
-
-    def __str__(self):
-        return f"{self._content}"
-
-    def __repr__(self) -> str:
-        return f"Some({self._content!r})" if self._content is not None else "Null()"
-
-    def __hash__(self) -> int:
-        return hash(self._content) * 41
-
-    def __eq__(self, other: object) -> bool:
-        return isinstance(other, type(self)) and self._content == other._content
-
-    def __ne__(self, other: object) -> bool:
-        return not self.__eq__(other)
-
-    def __iter__(self) -> Iterator[T | None]:
-        yield self._content or None
 
     @classmethod
     def some(cls, content: T) -> Option[T]:
@@ -418,7 +383,7 @@ class Option[T: object]:
         Examples:
         >>> assert Option.some(10) == Some(10)
         """
-        return cls(content)
+        return Some(content)
 
     @classmethod
     def none(cls) -> Option[T]:
@@ -426,40 +391,38 @@ class Option[T: object]:
         Creates an `Option` instance that contains a `Null` value.
 
         Examples:
-        >>> assert Option.null("Error") == Null("Error")
+        >>> assert Option.none() == Null()
         """
-        return cls()
+        return Null()
 
+    @abc.abstractmethod
     def and_then[U](self, op: Callable[[T], Option[U]]) -> Option[U]:
         """Returns [`Null`] if the option is [`Null`], otherwise calls `op` with the
         wrapped value and returns the result.
         Some languages call this operation flatmap.
         # Examples:
 
-        >>> err = "Not a number"
         >>> assert Some(2).and_then(sq_then_to_string) == Some("4")
-        >>> assert Null(err).and_then(sq_then_to_string) == Null(err)
+        >>> assert Null().and_then(sq_then_to_string) == Null()
         """
-        return op(self._content) if self._content is not None else self
 
+    @abc.abstractmethod
     def expect(self, msg: str) -> T:
         """
         Returns the contained [`Some`] value, consuming the `self` value.
 
         Raises
         ---
-            Panics if the value is a [`Null`] with a custom panic message provided by `msg`.
+            Raises `UnwrapFailedError` with the provided message if the value is a [`Null`].
         # Examples:
 
         >>> msg = "Something went wrong"
         >>> assert Some(10).expect(msg) == 10
         >>> with pytest.raises(UnwrapFailedError, match=msg):
-        ...     Null("Emergency failure").expect(msg)
+        ...     Null().expect(msg)
         """
-        if self._content is None:
-            raise UnwrapFailedError(msg)
-        return self._content
 
+    @abc.abstractmethod
     def filter(self, predicate: Callable[[T], bool]) -> Option[T]:
         """
         Returns [`Null`] if the option is [`Null`], otherwise calls `predicate`
@@ -475,22 +438,22 @@ class Option[T: object]:
         # Examples:
 
         >>> assert Some(10).filter(is_even) == Some(10)
-        >>> assert Some(15).filter(is_even) == Null(None)
-        >>> assert Null(10).filter(is_even) == Null(10)
+        >>> assert Some(15).filter(is_even) == Null()
+        >>> assert Null().filter(is_even) == Null()
         """
-        return self if self._content is None or predicate(self._content) else Null()
 
+    @abc.abstractmethod
     def is_some(self) -> bool:
         """
         Returns `true` if the option is a [`Some`] value.
 
         # Examples:
 
-        >>> assert not Null(10).is_some()
+        >>> assert not Null().is_some()
         >>> assert Some(10).is_some()
         """
-        return self._content is not None
 
+    @abc.abstractmethod
     def is_some_and(self, op: Callable[[T], bool]) -> bool:
         """
         Returns `true` if the option is a [`Some`] and the value inside of it matches a predicate.
@@ -499,21 +462,21 @@ class Option[T: object]:
 
         >>> assert Some(10).is_some_and(is_even)
         >>> assert not Some(15).is_some_and(is_even)
-        >>> assert not Null("Something went wrong").is_some_and(is_even)
+        >>> assert not Null().is_some_and(is_even)
         """
-        return self.is_some() and op(self._content)
 
+    @abc.abstractmethod
     def is_none(self) -> bool:
         """
         Returns `true` if the option is a [`Null`] value.
 
         # Examples:
 
-        >>> assert Null(10).is_null()
-        >>> assert not Some(10).is_null()
+        >>> assert Null().is_none()
+        >>> assert not Some(10).is_none()
         """
-        return not self.is_some()
 
+    @abc.abstractmethod
     def map[U](self, op: Callable[[T], U]) -> Option[U]:
         """
         Maps an `Option<T>` to `Option<U>` by applying a function to a contained value
@@ -522,10 +485,10 @@ class Option[T: object]:
         # Examples:
 
         >>> assert Some(10).map(lambda i: i * 2) == Some(20)
-        >>> assert Null("Nothing here").map(lambda i: i * 2) == Null("Nothing here")
+        >>> assert Null().map(lambda i: i * 2) == Null()
         """
-        return self if self._content is None else Some(op(self._content))
 
+    @abc.abstractmethod
     def map_or[U](self, default: U, op: Callable[[T], U]) -> U:
         """
         Returns the provided default result (if `Null`), or applies a function to the contained value (if `Some`).
@@ -533,10 +496,10 @@ class Option[T: object]:
         # Examples:
 
         >>> assert Some("foo").map_or(42, lambda v: len(v)) == 3
-        >>> assert Null("bar").map_or(42, lambda v: len(v)) == 42
+        >>> assert Null().map_or(42, lambda v: len(v)) == 42
         """
-        return default if self._content is None else op(self._content)
 
+    @abc.abstractmethod
     def map_or_else[U](self, default: Callable[[], U], op: Callable[[T], U]) -> U:
         """
         Computes a default function result (if `Null`), or
@@ -545,23 +508,21 @@ class Option[T: object]:
         # Examples:
 
         >>> assert Some("foo").map_or_else(lambda: 42, lambda v: len(v)) == 3
-        >>> assert Null("bar").map_or_else(lambda: 42, lambda v: len(v)) == 42
+        >>> assert Null().map_or_else(lambda: 42, lambda v: len(v)) == 42
         """
-        return default() if self._content is None else op(self._content)
 
+    @abc.abstractmethod
     def or_(self, default: Option[T]) -> Option[T]:
         """
-        Transforms the `Option<T>` into a [`Result<T, E>`], mapping [`Some(v)`] to
-        [`Ok(v)`] and [`Null`] to [`Err(err())`].
+        Returns the option if it contains a value, otherwise returns `default`.
 
         # Examples:
 
-        >>> msg = "Something went wrong"
-        >>> assert Some(10).ok_or_else(lambda: msg) == Result.Ok(10)
-        >>> assert Null(10).ok_or_else(lambda: msg) == Result.Err(msg)
+        >>> assert Some(2).or_(Null()) == Some(2)
+        >>> assert Null().or_(Some(100)) == Some(100)
         """
-        return default if self._content is None else self
 
+    @abc.abstractmethod
     def or_else(self, op: Callable[[], Option[T]]) -> Option[T]:
         """
         Returns the option if it contains a value, otherwise calls `f` and
@@ -570,11 +531,11 @@ class Option[T: object]:
         # Examples
 
         >>> assert Some(10).or_else(lambda: Some(20)) == Some(10)
-        >>> assert Some(10).or_else(lambda: Null(20)) == Some(10)
-        >>> assert Null(10).or_else(lambda: Some(20)) == Some(20)
+        >>> assert Some(10).or_else(lambda: Null()) == Some(10)
+        >>> assert Null().or_else(lambda: Some(20)) == Some(20)
         """
-        return op() if self._content is None else self
 
+    @abc.abstractmethod
     def ok_or[E](self, err: E) -> Result[T, E]:
         """
         Transforms the `Option<T>` into a [`Result<T, E>`], mapping [`Some(v)`] to
@@ -584,10 +545,10 @@ class Option[T: object]:
 
         >>> msg = "Something went wrong"
         >>> assert Some(10).ok_or(msg) == Result.Ok(10)
-        >>> assert Null(10).ok_or(msg) == Result.Err(msg)
+        >>> assert Null().ok_or(msg) == Result.Err(msg)
         """
-        return Ok(self._content) if self._content is not None else Err(err)
 
+    @abc.abstractmethod
     def ok_or_else[E](self, op: Callable[[], E]) -> Result[T, E]:
         """
         Transforms the `Option<T>` into a [`Result<T, E>`], mapping [`Some(v)`] to
@@ -597,10 +558,10 @@ class Option[T: object]:
 
         >>> msg = "Something went wrong"
         >>> assert Some(10).ok_or_else(lambda: msg) == Result.Ok(10)
-        >>> assert Null(10).ok_or_else(lambda: msg) == Result.Err(msg)
+        >>> assert Null().ok_or_else(lambda: msg) == Result.Err(msg)
         """
-        return Ok(self._content) if self._content is not None else Err(op())
 
+    @abc.abstractmethod
     def transpose[E](self) -> Result[Option[T], E]:
         """
         Transposes an `Option` of a [`Result`] into a [`Result`] of an `Option`.
@@ -616,14 +577,119 @@ class Option[T: object]:
         >>> no_result = "No result"
         >>> assert Some(Result.Ok("foo")).transpose() == Result.Ok(Some("foo"))
         >>> assert Some(Result.Err(msg)).transpose() == Result.Err(msg)
-        >>> assert Null(Result.Ok("foo")).transpose() == Result.Ok(Some(None))
-        >>> assert Null(Result.Err(msg)).transpose() == Result.Ok(Some(None))
+        >>> assert Null().transpose() == Result.Ok(Null())
         >>> assert Some(no_result).transpose() == Result.Ok(Some(no_result))
-        >>> assert Null(no_result).transpose() == Result.Ok(Some(None))
         """
-        match self._content:
-            case None:
-                return Ok(Null())
+
+    @abc.abstractmethod
+    def unwrap(self) -> T:
+        """
+        Returns the contained [`Some`] value.
+
+        Because this function may panic, its use is generally discouraged.
+        Instead, prefer to use pattern matching and handle the [`Null`]
+        case explicitly, or call [`unwrap_or`], [`unwrap_or_else`].
+
+        # Raises
+            Raises UnwrapFailedError when the option is [`Null`].
+
+        # Examples
+
+        >>> assert Some(10).unwrap() == 10
+        >>> Null().unwrap()
+        Traceback (most recent call last):
+            ...
+            results.results.UnwrapFailedError: Called `.unwrap` on an [`Null`] value.
+
+        """
+
+    @abc.abstractmethod
+    def unwrap_or(self, default: T) -> T:
+        """
+        Returns the contained [`Some`] value or a provided default.
+
+        # Examples
+
+        >>> assert Some(10).unwrap_or(42) == 10
+        >>> assert Null().unwrap_or(42) == 42
+        """
+
+    @abc.abstractmethod
+    def unwrap_or_else(self, op: Callable[[], T]) -> T:
+        """
+        Returns the contained [`Some`] value or computes it from a closure.
+
+        # Examples
+
+        >>> assert Some(10).unwrap_or_else(lambda: 42) == 10
+        >>> assert Null().unwrap_or_else(lambda: 42) == 42
+        """
+
+
+@final
+class Some[T](Option[T]):
+    __slots__ = ("_value",)
+    __match_args__ = ("_value",)
+
+    def __init__(self, value: T) -> None:
+        self._value = value
+
+    def __str__(self) -> str:
+        return f"{self._value}"
+
+    def __repr__(self) -> str:
+        return f"Some({self._value!r})"
+
+    def __hash__(self) -> int:
+        return hash(self._value) * 41
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Some) and self._value == other._value
+
+    def __iter__(self) -> Iterator[T]:
+        yield self._value
+
+    def and_then[U](self, op: Callable[[T], Option[U]]) -> Option[U]:
+        return op(self._value)
+
+    def expect(self, msg: str) -> T:
+        return self._value
+
+    def filter(self, predicate: Callable[[T], bool]) -> Option[T]:
+        return self if predicate(self._value) else Null()
+
+    def is_some(self) -> Literal[True]:
+        return True
+
+    def is_some_and(self, op: Callable[[T], bool]) -> bool:
+        return op(self._value)
+
+    def is_none(self) -> Literal[False]:
+        return False
+
+    def map[U](self, op: Callable[[T], U]) -> Option[U]:
+        return Some(op(self._value))
+
+    def map_or[U](self, default: U, op: Callable[[T], U]) -> U:
+        return op(self._value)
+
+    def map_or_else[U](self, default: Callable[[], U], op: Callable[[T], U]) -> U:
+        return op(self._value)
+
+    def or_(self, default: Option[T]) -> Option[T]:
+        return self
+
+    def or_else(self, op: Callable[[], Option[T]]) -> Option[T]:
+        return self
+
+    def ok_or[E](self, err: E) -> Result[T, E]:
+        return Ok(self._value)
+
+    def ok_or_else[E](self, op: Callable[[], E]) -> Result[T, E]:
+        return Ok(self._value)
+
+    def transpose[E](self) -> Result[Option[T], E]:
+        match self._value:
             case Ok(value):
                 return Ok(Some(value))
             case Err() as err:
@@ -632,48 +698,82 @@ class Option[T: object]:
                 return Ok(self)
 
     def unwrap(self) -> T:
-        """
-        Returns the contained [`Some`] value.
-
-        Because this function may panic, its use is generally discouraged.
-        Instead, prefer to use pattern matching and handle the [`Null`]
-        case explicitly, or call [`unwrap_or`], [`unwrap_or_else`], or
-        [`unwrap_or_default`].
-
-        # Raises
-            Raises UnwrapFailedError when the value equals None.
-
-        # Examples
-
-        >>> assert Some(10).unwrap() == 10
-        >>> assert Null(10).unwrap() == 10
-        Traceback (most recent call last):
-            ...
-            option.option.UnwrapFailedError: Called `.unwrap` on an [`Null`] value.
-
-        """
-        if self._content is None:
-            raise UnwrapFailedError("Called `.unwrap` on an [`Null`] value.")
-        return self._content
+        return self._value
 
     def unwrap_or(self, default: T) -> T:
-        """
-        Returns the contained [`Some`] value or a provided default.
-
-        # Examples
-
-        >>> assert Some(10).unwrap_or(42) == 10
-        >>> assert Null(10).unwrap_or(42) == 42
-        """
-        return self._content or default
+        return self._value
 
     def unwrap_or_else(self, op: Callable[[], T]) -> T:
-        """
-        Returns the contained [`Some`] value or computes it from a closure.
+        return self._value
 
-        # Examples
 
-        >>> assert Some(10).unwrap_or_else(lambda: 42) == 10
-        >>> assert Null(10).unwrap_or_else(lambda: 42) == 42
-        """
-        return self._content or op()
+@final
+class Null[T](Option[T]):
+    __slots__ = ()
+    __match_args__ = ()
+
+    def __str__(self) -> str:
+        return f"{None}"
+
+    def __repr__(self) -> str:
+        return "Null()"
+
+    def __hash__(self) -> int:
+        return hash(None) * 41
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Null)
+
+    def __iter__(self) -> Iterator[None]:
+        yield None
+
+    def and_then[U](self, op: Callable[[T], Option[U]]) -> Option[U]:
+        return Null()
+
+    def expect(self, msg: str) -> NoReturn:
+        raise UnwrapFailedError(msg)
+
+    def filter(self, predicate: Callable[[T], bool]) -> Option[T]:
+        return self
+
+    def is_some(self) -> Literal[False]:
+        return False
+
+    def is_some_and(self, op: Callable[[T], bool]) -> Literal[False]:
+        return False
+
+    def is_none(self) -> Literal[True]:
+        return True
+
+    def map[U](self, op: Callable[[T], U]) -> Option[U]:
+        return Null()
+
+    def map_or[U](self, default: U, op: Callable[[T], U]) -> U:
+        return default
+
+    def map_or_else[U](self, default: Callable[[], U], op: Callable[[T], U]) -> U:
+        return default()
+
+    def or_(self, default: Option[T]) -> Option[T]:
+        return default
+
+    def or_else(self, op: Callable[[], Option[T]]) -> Option[T]:
+        return op()
+
+    def ok_or[E](self, err: E) -> Result[T, E]:
+        return Err(err)
+
+    def ok_or_else[E](self, op: Callable[[], E]) -> Result[T, E]:
+        return Err(op())
+
+    def transpose[E](self) -> Result[Option[T], E]:
+        return Ok(Null())
+
+    def unwrap(self) -> NoReturn:
+        raise UnwrapFailedError("Called `.unwrap` on an [`Null`] value.")
+
+    def unwrap_or(self, default: T) -> T:
+        return default
+
+    def unwrap_or_else(self, op: Callable[[], T]) -> T:
+        return op()

--- a/tests/results/test_option.py
+++ b/tests/results/test_option.py
@@ -45,7 +45,7 @@ def test_expect_when_some_should_return_value() -> None:
 
 
 def test_expect_when_null_should_raise_error() -> None:
-    option = Null()
+    option: Option = Null()
     msg = "Something went wrong"
     with pytest.raises(UnwrapFailedError, match=msg):
         option.expect(msg)
@@ -265,11 +265,19 @@ def test_or_else_when_null_should_call_the_given_function_or_return_the_some_val
         (Some(10), 10),
         (Null(), None),
         (Some("test"), "test"),
+        (Some(0), 0),
+        (Some(""), ""),
+        (Some([]), []),
+        (Some(None), None),
     ],
     ids=[
         "test_iter_when_some_with_int_should_yield_int",
         "test_iter_when_null_with_none_should_yield_none",
         "test_iter_when_some_with_str_should_yield_str",
+        "test_iter_when_some_with_zero_should_yield_zero",
+        "test_iter_when_some_with_empty_str_should_yield_empty_str",
+        "test_iter_when_some_with_empty_list_should_yield_empty_list",
+        "test_iter_when_some_with_none_should_yield_none",
     ],
 )
 def test_iter(option, expected):
@@ -283,12 +291,16 @@ def test_iter(option, expected):
         (Null(), "Null()"),
         (Some("test"), "Some('test')"),
         (Null(), "Null()"),
+        (Some(None), "Some(None)"),
+        (Some(0), "Some(0)"),
     ],
     ids=[
         "test_repr_when_some_with_int_should_return_formatted_string",
         "test_repr_when_null_with_none_should_return_formatted_string",
         "test_repr_when_some_with_str_should_return_formatted_string",
         "test_repr_when_null_with_str_should_return_formatted_string",
+        "test_repr_when_some_none_should_return_some_none_not_null",
+        "test_repr_when_some_zero_should_return_some_zero",
     ],
 )
 def test_repr(option, expected):
@@ -300,17 +312,24 @@ def test_str_when_some_should_return_value_string() -> None:
     assert str(Null()) == "None"
 
 
+def test_option_base_class_cannot_be_instantiated_directly() -> None:
+    with pytest.raises(TypeError):
+        Option()  # type: ignore[abstract]
+
+
 @pytest.mark.parametrize(
     "options, expected",
     [
         ({Some(1), Null(), Some(1), Null()}, 2),
         ({Some(1), Some(2)}, 2),
         ({Some("a"), Null()}, 2),
+        ({Some(None), Null(), Some(None), Null()}, 2),
     ],
     ids=[
         "test_hash_when_some_and_no_duplicates_should_return_correct_length",
         "test_hash_when_different_some_values_should_return_correct_length",
         "test_hash_when_some_and_null_strings_should_return_correct_length",
+        "test_hash_when_some_none_and_null_should_remain_distinct_members",
     ],
 )
 def test_hash(options, expected) -> None:
@@ -327,6 +346,10 @@ def test_hash(options, expected) -> None:
         (Some(10), Null(), False),
         (Some(10), Some(20), False),
         (Null(), Null(), True),
+        (Some(None), Null(), False),
+        (Some(None), Some(None), True),
+        (Some(0), Null(), False),
+        (Some(""), Null(), False),
     ],
     ids=[
         "test_eq_when_some_with_same_int_should_return_true",
@@ -336,6 +359,10 @@ def test_hash(options, expected) -> None:
         "test_eq_when_some_and_null_with_same_int_should_return_false",
         "test_eq_when_some_with_different_int_should_return_false",
         "test_eq_when_null_with_different_values_should_return_true",
+        "test_eq_when_some_none_and_null_should_return_false",
+        "test_eq_when_both_some_none_should_return_true",
+        "test_eq_when_some_zero_and_null_should_return_false",
+        "test_eq_when_some_empty_str_and_null_should_return_false",
     ],
 )
 def test_eq(option1, option2, expected):
@@ -351,6 +378,8 @@ def test_eq(option1, option2, expected):
         (Null(), Null(), False),
         (Some(10), Null(), True),
         (Some(10), Some(20), True),
+        (Some(None), Null(), True),
+        (Some(0), Null(), True),
     ],
     ids=[
         "test_ne_when_some_with_same_int_should_return_false",
@@ -359,6 +388,8 @@ def test_eq(option1, option2, expected):
         "test_ne_when_null_with_same_str_should_return_false",
         "test_ne_when_some_and_null_with_same_int_should_return_true",
         "test_ne_when_some_with_different_int_should_return_true",
+        "test_ne_when_some_none_and_null_should_return_true",
+        "test_ne_when_some_zero_and_null_should_return_true",
     ],
 )
 def test_ne(option1, option2, expected):
@@ -401,10 +432,18 @@ def test_unwrap_when_null_should_raise_error() -> None:
     [
         (Some(2), 42, 2),
         (Null(), 42, 42),
+        (Some(0), 42, 0),
+        (Some(""), "x", ""),
+        (Some([]), [1], []),
+        (Some(None), 42, None),
     ],
     ids=[
         "test_unwrap_or_when_some_should_return_value",
         "test_unwrap_or_when_null_should_return_default",
+        "test_unwrap_or_when_some_zero_should_return_zero_not_default",
+        "test_unwrap_or_when_some_empty_str_should_return_empty_str_not_default",
+        "test_unwrap_or_when_some_empty_list_should_return_empty_list_not_default",
+        "test_unwrap_or_when_some_none_should_return_none_not_default",
     ],
 )
 def test_unwrap_or_when_some_value_should_return_value_or_provided_default(
@@ -418,10 +457,16 @@ def test_unwrap_or_when_some_value_should_return_value_or_provided_default(
     [
         (Some(2), lambda: 3, 2),
         (Null(), lambda: 3, 3),
+        (Some(0), lambda: 3, 0),
+        (Some(""), lambda: "x", ""),
+        (Some(None), lambda: 3, None),
     ],
     ids=[
         "test_unwrap_or_else_when_some_should_return_value",
         "test_unwrap_or_else_when_null_should_call_func_and_return_value",
+        "test_unwrap_or_else_when_some_zero_should_return_zero_not_func",
+        "test_unwrap_or_else_when_some_empty_str_should_return_empty_str_not_func",
+        "test_unwrap_or_else_when_some_none_should_return_none_not_func",
     ],
 )
 def test_unwrap_or_else_when_some_value_should_return_value_or_compute_from_function(
@@ -455,14 +500,14 @@ def test_or_else_when_some_should_return_some(option, func, expected):
         (Some(Ok(5)), Ok(Some(5))),
         (Some(Err("error")), Err("error")),
         (Some(Ok(None)), Ok(Some(None))),
-        (Null(), Ok(Some(None))),
+        (Null(), Ok(Null())),
         (Some(5), Ok(Some(5))),
     ],
     ids=[
         "transpose_when_some_ok_should_return_ok_with_some_value",
         "transpose_when_some_err_should_return_err",
         "transpose_when_some_ok_none_should_return_ok_with_some_none",
-        "transpose_when_null_err_should_return_ok_none",
+        "transpose_when_null_should_return_ok_with_null",
         "transpose_when_some_value_should_return_ok_some_value",
     ],
 )

--- a/tests/results/test_pattern_matching.py
+++ b/tests/results/test_pattern_matching.py
@@ -3,20 +3,34 @@ from __future__ import annotations
 from results import Null, Option, Some
 
 
-def test_pattern_matching_on_ok_type() -> None:
+def test_pattern_matching_on_some_type() -> None:
     o = Some("yay")
+    reached = False
     match o:
-        case Option(value):
+        case Some(value):
             reached = True
 
     assert value == "yay"
     assert reached
 
 
-def test_pattern_matching_on_err_type() -> None:
-    n = Null()
+def test_pattern_matching_on_null_type() -> None:
+    n: Option = Null()
+    reached = False
     match n:
-        case Option(None):
+        case Null():
             reached = True
 
     assert reached
+
+
+def test_pattern_matching_distinguishes_some_none_from_null() -> None:
+    o = Some(None)
+    match o:
+        case Null():
+            branch = "null"
+        case Some(value):
+            branch = "some"
+
+    assert branch == "some"
+    assert value is None


### PR DESCRIPTION
## Summary

Redesigns `Option[T]` to mirror the existing `Result`/`Ok`/`Err` model: a sealed `abc.ABC` with two `@final` subclasses — `Some[T]` (value present) and `Null[T]` (value absent). Absence is now encoded in the **type** rather than the value `None`, and every method is selected by **polymorphic dispatch** — no `_content is None` branching, no truthiness shortcuts. The base ABC is no longer directly instantiable; `Some(...)` and `Null()` are the only constructors and keep their current signatures.

This makes illegal states unrepresentable, exactly as `Result` already does.

## Acceptance criteria (all met)

- [x] `Option` is a sealed two-state type with polymorphic dispatch; no branching on `_content is None`.
- [x] `Some(None) != Null()`, distinguishable via `__repr__` (`Some(None)` vs `Null()`) and `__eq__`.
- [x] `Some(0)`, `Some("")`, `Some([])` are treated as **present** by `unwrap_or`, `unwrap_or_else`, and `__iter__`.
- [x] The ambiguous empty state cannot be constructed directly — `Option()` raises `TypeError`; `Some(...)` / `Null()` are the only entry points.
- [x] `case Some(v)` / `case Null()` pattern matching works via `__match_args__`.
- [x] All existing Option methods preserved with their semantics (`and_then`, `filter`, `is_some`, `is_some_and`, `is_none`, `map`, `map_or`, `map_or_else`, `or_`, `or_else`, `ok_or`, `ok_or_else`, `transpose`, `unwrap`, `expect`, `unwrap_or`, `unwrap_or_else`, `__eq__`, `__hash__`, `__repr__`, `__str__`, `__iter__`, `some`/`none`, `from_fn`/`as_option`).
- [x] Tests added/updated in the existing parametrized tables; CONTEXT.md and CLAUDE.md updated.

## Design

- `Some[T]` carries `_value` (slot), `Null[T]` carries nothing (`__slots__ = ()`).
- `transpose` stays behaviorally identical: `Null.transpose()` → `Ok(Null())`; `Some.transpose()` matches on its inner content (`Ok`/`Err`/other) — issue #5's territory, unchanged.
- `Option.some()` / `Option.none()` kept as thin delegators to the new subclasses so the existing classmethod API stays callable.

## Also completes the Option-side of #4 and #6

- **#4 (Option-side):** `Option.as_option` now delegates to `Option.from_fn` instead of duplicating the `None`-check inner.
- **#6 (Option-side):** removed the redundant `Option.__ne__`; `!=` is auto-derived from `__eq__`.

## ⚠️ Breaking change (warrants a major-version bump)

- `Some(None) != Null()` now (previously `==` via the None-collapse).
- Falsy `Some(...)` values (`Some(0)`, `Some("")`, `Some([])`) are **no longer treated as absent** — e.g. `Some(0).unwrap_or(42) == 0` (was `42`).
- `Option(...)` direct construction is **removed** — the base ABC is abstract.

## Checks

- `uv run pytest` → 154 passed
- `uv run mypy src tests` → clean (also fixed 4 pre-existing `results.py` mypy errors that the old single-class design carried)
- `uv run ruff check` / `ruff format --check` → clean

## Review findings

Self-review (the thermo-nuclear skill is C#/.NET-scoped) found no residual `_content is None` branching, no truthiness leaks, and both subclasses implement all 17 abstract methods. No leftover findings.

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)