### PR TITLE
feat!: forbid Some(None), raise ValueError at construction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@ __`Result[T, E]`__ is an `abc.ABC` with two `@final` concrete subclasses, `Ok[T]
 
 __`Option[T]`__ mirrors `Result`'s design: an `abc.ABC` with two `@final` concrete subclasses, `Some[T]` (value present) and `Null[T]` (value absent). Absence is encoded in the *type* — there is no stored `None` sentinel — so behavior is selected by *polymorphism*, never by `_content is None` or truthiness checks inside a method. `Some(value)` and `Null()` are the only constructors (the base ABC is not directly instantiable). When adding a method to `Option`, add the `@abc.abstractmethod` stub plus a `Some` and a `Null` implementation. Consequences to keep in mind:
 
-- `Some(None) != Null()` — present-but-`None` is a distinct, legal state.
-- `unwrap_or` / `unwrap_or_else` / `__iter__` dispatch structurally on the variant, so falsy values like `0` / `""` / `[]` are treated as *present* (e.g. `Some(0).unwrap_or(42) == 0`).
+- `Some(None)` is forbidden and raises `ValueError` (guard in `Some.__init__`) — `None` is solely the absence sentinel, represented only by `Null()`. Any path that would wrap `None` raises too: `Ok(None).ok()`, `Some(5).map(lambda _: None)`, `Some(Ok(None)).transpose()`. Rule of thumb: `map` (`T -> U`) must not produce `None`; for a step that may be absent use `and_then` (`T -> Option[U]`), and for absence use `Null()`.
+- `unwrap_or` / `unwrap_or_else` / `__iter__` dispatch structurally on the variant, so falsy values like `0` / `""` / `[]` are treated as *present* (e.g. `Some(0).unwrap_or(42) == 0`). `None` is not a present value — `Some(None)` raises.
 
 __Cross-conversions__ tie the two families together: `Result.ok()` / `Result.err()` produce an `Option`; `Option.ok_or()` / `Option.ok_or_else()` produce a `Result`; `Option.transpose()` swaps an `Option[Result]` into a `Result[Option]`.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,8 +84,9 @@ nie eine `_content is None`- oder Truthiness-Abfrage im Methodenrumpf.
 
 - Invariante: `Option` selbst wird nie instanziiert (die ABC ist nicht direkt
   konstruierbar) — eine Instanz ist immer **genau eine** der Varianten `Some` oder
-  `Null`. Weil Abwesenheit ein eigener Typ ist, ist `Some(None)` ein legaler,
-  **vorhandener** Zustand und von `Null()` unterscheidbar (`Some(None) != Null()`).
+  `Null`. `None` ist ausschließlich das Absenz-Sentinel mit genau **einer**
+  Repräsentation, `Null()`. `Some(None)` ist daher verboten und wirft
+  `ValueError`; ein lebendes `Some` umschließt nie `None`.
 
 *Avoid:* „`typing.Optional`", „nullable Referenz". `Option` ist ein eigenes
 Wrapper-Objekt; `Optional[T]` ist bloß `T | None` ohne Methoden.
@@ -95,8 +96,9 @@ Wrapper-Objekt; `Optional[T]` ist bloß `T | None` ohne Methoden.
 Die vorhandene Variante von `Option`; `@final`-Subklasse, die genau einen Wert vom
 Typ `T` hält. `Some(value)` ist ihr Konstruktor.
 
-- Invariante: `Some(v).is_some()` ist **immer** `True` — auch für `v is None`
-  (`Some(None)` ist ein vorhandener Zustand, verschieden von `Null()`).
+- Invariante: ein lebendes `Some` umschließt **nie** `None`. `Some(v).is_some()`
+  ist `True` für jedes `v is not None`; `Some(None)` wirft `ValueError` (Guard in
+  `Some.__init__`).
 
 *Avoid:* „Just" (Haskell), „present()". `Some(5)` ist ein Container um `5`, nicht die
 Zahl `5` selbst.
@@ -107,8 +109,8 @@ Die abwesende Variante von `Option`; `@final`-Subklasse ohne gespeicherten Wert.
 `Null()` ist ihr Konstruktor und nimmt **keine** Argumente.
 
 - Invariante: `Null().is_none()` ist `True`; alle Varianten sind untereinander
-  gleich (`Null() == Null()`) und von jedem `Some(...)` verschieden — auch von
-  `Some(None)`.
+  gleich (`Null() == Null()`) und von jedem `Some(...)` verschieden. `Some(None)`
+  existiert nicht — die Konstruktion wirft `ValueError`.
 
 *Avoid:* „Pythons `None`", „Nil", „Nothing". `Null()` ist ein eigenständiger
 `Option`-Typ für Abwesenheit — nicht das `None` selbst und kein `Some`, das ein
@@ -138,9 +140,12 @@ den enthaltenen Wert oder einen Ersatz, ohne je zu werfen.
 - Invariante (`Result`): Der Rückfall greift genau bei `Err`.
 - Invariante (`Option`): Der Rückfall greift **strukturell** genau bei `Null` —
   per Polymorphie auf der Variante, nicht per Wahrheitswert. Folge: Falsy-Inhalte
-  wie `0`, `""`, `[]` (und auch `None`) sind **vorhanden** und werden zurückgegeben;
-  `Some(0).unwrap_or(42)` ist `0`. Dieselbe strukturelle Logik gilt für die
-  Iteration über ein `Option`: `Some(0)` iteriert zu `[0]`, `Null()` zu `[None]`.
+  wie `0`, `""`, `[]` sind **vorhanden** und werden zurückgegeben;
+  `Some(0).unwrap_or(42)` ist `0`. `None` ist kein Wert, sondern Absenz:
+  `Some(None)` ist verboten und wirft `ValueError`; Abwesenheit drückt man mit
+  `Null()` aus.
+  Dieselbe strukturelle Logik gilt für die Iteration über ein `Option`: `Some(0)`
+  iteriert zu `[0]`, `Null()` zu `[None]`.
 
 *Avoid:* anzunehmen, `Option.unwrap_or` prüfe Truthiness — der alte
 `self._content or default`-Trick ist weg. Es entscheidet die Variante (`Some` vs.
@@ -183,8 +188,8 @@ Brücken zwischen den beiden Familien, die einen Typ in den anderen überführen
 - Invariante: `ok_or`/`ok_or_else` entscheiden **strukturell** über die Variante
   (`Some` vs. `Null`), nicht per Truthiness oder `is None`, daher bleibt `Some(0)`
   ein `Ok(0)`.
-- `Ok(None).ok()` ergibt `Some(None)` — ein **vorhandenes** `Option`, das von
-  `Null()` verschieden ist (`Ok(_).ok()` ist immer ein `Some`, nie `Null()`).
+- `Ok(None).ok()` wirft `ValueError` — `Ok(_).ok()` würde `Some(_)` bauen, und
+  `Some(None)` ist verboten (`Ok(v).ok()` ist `Some(v)` für `v is not None`).
 
 *Avoid:* „Cast"/„isinstance-Umwandlung". Es entsteht jeweils ein **neues** Objekt der
 Zielfamilie; das Original wird nicht verändert.
@@ -195,7 +200,7 @@ Zielfamilie; das Original wird nicht verändert.
 in ein `Result` **eines** `Option`:
 
 - `Null()` → `Ok(Null())`
-- `Some(Ok(v))` → `Ok(Some(v))`
+- `Some(Ok(v))` → `Ok(Some(v))` (ist `v` `None`, wirft `Some(v)` → `ValueError`)
 - `Some(Err(e))` → `Err(e)`
 - nicht-`Result`-Inhalt → `Ok(self)` (unverändert eingepackt)
 
@@ -237,9 +242,10 @@ Wert); `ResultError` ist eine **geworfene Ausnahme**.
 
 ### UnwrapFailedError
 
-`ResultError`-Subklasse und die einzige tatsächlich geworfene Ausnahme der
-Bibliothek: ausgelöst von fehlgeschlagenem `unwrap`/`expect`/`unwrap_err`/`expect_err`
-— sowohl auf `Result` als auch auf `Option`.
+`ResultError`-Subklasse und die einzige *bibliothekseigene* geworfene Ausnahme:
+ausgelöst von fehlgeschlagenem `unwrap`/`expect`/`unwrap_err`/`expect_err` — sowohl
+auf `Result` als auch auf `Option`. (Daneben wirft allein die verbotene
+Konstruktion `Some(None)` das eingebaute `ValueError`.)
 
 - Invariante: Auch `Option.unwrap` wirft diese **Result-seitige** Klasse; es gibt
   keine eigene Option-seitige Fehlerklasse.
@@ -248,16 +254,16 @@ Bibliothek: ausgelöst von fehlgeschlagenem `unwrap`/`expect`/`unwrap_err`/`expe
 
 ## Beispieldialog
 
-**1 — `Some(None)` ist „vorhanden", verschieden von `Null()`**
+**1 — `Some(None)` ist verboten — `None` ist Absenz**
 
 > **Entwickler:** Ich packe ein optionales Ergebnis in `Some(result)`. Wenn `result`
 > mal `None` ist, behalte ich doch immer noch ein „vorhandenes" `Some`, oder?
 >
-> **Expertin:** Ja. `Option` ist ein versiegelter Zwei-Zustands-Typ: Abwesenheit
-> steckt im **Typ** (`Null`), nicht im Wert. `Some(None)` ist deshalb ein
-> vorhandener Zustand und von `Null()` unterscheidbar — `Some(None) == Null()` ist
-> `False`, und die `repr`s lauten `Some(None)` bzw. `Null()`. „Vorhanden, aber
-> `None`" ist hier ein gültiger, ausdrückbarer Zustand.
+> **Expertin:** Nein. `None` ist ausschließlich das Absenz-Sentinel und hat genau
+> **eine** Repräsentation: `Null()`. `Some(None)` ist deshalb verboten und wirft
+> `ValueError`. „Vorhanden, aber `None`" gibt es nicht: für einen echten Wert nimm
+> etwas, das nicht `None` ist; für Abwesenheit `Null()`. Hast du ein optionales
+> Zwischenergebnis (`T -> Option[U]`), nimm `and_then`, nicht `map` (`T -> U`).
 
 **2 — `Option.unwrap_or` prüft die Variante, nicht Truthiness**
 
@@ -266,9 +272,10 @@ Bibliothek: ausgelöst von fehlgeschlagenem `unwrap`/`expect`/`unwrap_err`/`expe
 >
 > **Expertin:** Richtig, es gibt `0` zurück. `Option.unwrap_or` entscheidet
 > **strukturell** über die Variante (`Some` vs. `Null`), nicht per Wahrheitswert.
-> Falsy-Werte wie `0`, `""`, `[]` (und `None`) bleiben „vorhanden" und werden
-> geliefert; nur `Null()` fällt auf den Default zurück. Genau wie auf der
-> `Result`-Seite: `Ok(0).unwrap_or(42)` ist `0`.
+> Falsy-Werte wie `0`, `""`, `[]` bleiben „vorhanden" und werden geliefert; nur
+> `Null()` fällt auf den Default zurück. `None` ist kein Wert — `Some(None)` ist
+> verboten (`ValueError`). Genau wie auf der `Result`-Seite: `Ok(0).unwrap_or(42)`
+> ist `0`.
 
 **3 — `map` vs. `and_then` (doppelte Verschachtelung)**
 

--- a/decisions/forbid-some-none.md
+++ b/decisions/forbid-some-none.md
@@ -1,0 +1,61 @@
+# Entscheidungs-Log — `Some(None)` verbieten
+
+Zusätzliche Invariante: `Some` umschließt immer einen echten Wert `T`; `None` ist
+ausschließlich das Absenz-Sentinel und wird allein durch `Null` repräsentiert.
+`Some(None)` darf nicht konstruierbar sein. Offene Punkte autonom gemäß
+Entscheidungsreihenfolge gelöst: 1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) ·
+2. Code-Konventionen · 3. Rust-`Option`-Semantik · 4. ponytail-Default.
+
+Kehrt die `#7`-Festlegung `Some(None) != Null()` um (siehe
+[issue-7-seal-option-two-state.md](issue-7-seal-option-two-state.md) E7).
+
+## E1 — Verhalten an der Some-Grenze: hart werfen (A)
+
+- **Offener Punkt:** `Some(None)` → A) hart abweisen (wirft) oder B) zu `Null()`
+  normalisieren.
+- **Entscheidung:** **A** — `Some(None)` wirft `ValueError`. Eine Regel, überall
+  gleich angewandt: jeder Pfad, der `None` in ein `Some` packen würde, wirft.
+- **Begründung:**
+  - Semantik der Kombinatoren: `map` ist `T -> U`. Hat man ein *optionales*
+    Zwischenergebnis, ist `and_then` (`T -> Option[U]`) das richtige Werkzeug, nicht
+    `map`. `Some(None)` — direkt oder über `map`, das `None` liefert — ist damit ein
+    **Programmierfehler** und soll laut scheitern, nicht still verschwinden.
+  - Gegen B: Normalisieren erzwang `cast("Some[T]", Null())` in `__new__` — das
+    verbiegt nur den eingehenden Typ, um den Typechecker ruhigzustellen. Ein
+    Cast, der eine `Null` als `Some[T]` ausgibt, ist der Beleg, dass das Design
+    nicht stimmt; A braucht keinen.
+  - `ValueError` als Fehlertyp (laziest, keine neue Klasse; idiomatisch „ungültiger
+    Argumentwert").
+- **Verworfen:** B (normalisieren). Versteckt den Fehler und verlangt den Typ-Cast.
+
+## E2 — Durchsetzungsort: Guard in `Some.__init__`
+
+- **Offener Punkt:** Wo den Wurf erzwingen — `Some.__init__`, `Option.some()` oder
+  jede `Some(...)`-Aufrufstelle?
+- **Entscheidung:** `if value is None: raise ValueError(...)` in `Some.__init__`.
+- **Begründung:** ponytail — eine Stelle deckt **alle** Konstruktionspfade ab.
+  `Option.some(None)`, `Ok(None).ok()`, `Some.map` → `None`, `Some.transpose` über
+  `Some(None)` werfen dadurch automatisch — gewollt (eine Regel überall, kein
+  Guard pro Aufrufstelle, kein Doppel-Verhalten).
+- **Verworfen:** `__new__` (nötig nur für die verworfene Normalisierung); ein
+  None-bewusster Privat-Konstruktor neben einem werfenden öffentlichen (zwei Regeln).
+
+## E3 — Typprüfungs-Grenze
+
+- **Offener Punkt:** „`T` ist nicht `None`" statisch ausdrücken.
+- **Entscheidung:** Nicht möglich mit PEP-695-Generics; Durchsetzung ist
+  **Laufzeit-only**, im Code per `ponytail:`-Kommentar benannt. Kein Cast nötig —
+  `__init__` wirft, es findet kein Typwechsel statt.
+- **Begründung:** Aufgaben-Vorgabe; `from_fn`/`as_option` bleiben unverändert konform
+  (sie bildeten `None` → `Null` schon ab, bauen also nie `Some(None)`).
+
+## E4 — Doku & Tests synchron
+
+- **Entscheidung:** `Option`-Docstring umgekehrt; `CLAUDE.md`-Bullet und alle
+  `CONTEXT.md`-Einträge (`Option`/`Some`/`Null`/`unwrap_or`/Cross-Conversion/
+  `transpose`/`UnwrapFailedError` + Beispieldialoge 1 & 2) auf „wirft `ValueError`"
+  umgestellt. Tests: alle `Some(None)`-Zeilen aus den Parametrize-Tabellen entfernt
+  (sie würden bei der Collection werfen), stattdessen `test_some_none_is_forbidden`
+  (direkt, `Option.some`, `map` → `None`, `transpose`) und
+  `test_ok_when_ok_none_is_forbidden`.
+- **Begründung:** `CLAUDE.md`-Mandat „Code ist Quelle der Wahrheit — Glossar folgt".

--- a/decisions/issue-4-dedup-result-constructors.md
+++ b/decisions/issue-4-dedup-result-constructors.md
@@ -1,22 +1,26 @@
 # Entscheidungs-Log — Issue #4 (Dedup der Result-Konstruktoren)
 
 Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
 1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
-3. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default (laziest funktionierend).
+2. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default (laziest funktionierend).
 
 ## E1 — Scope: nur die Result-Seite statt aller vier Konstruktoren
+
 - **Offener Punkt:** Issue #4 nennt vier „callable constructors"; soll dieser PR alle vier dedupen?
 - **Entscheidung:** Nur `Result.as_result` → delegiert an `Result.from_fn`. `Option.from_fn`/`Option.as_option` bleiben unangetastet.
 - **Begründung:** Maintainer-Re-Scoping + Konvention „ein Anliegen pro PR". Die Option-Seite liefert die `Option`-Neufassung in #7. Parallele PRs müssen disjunkt bleiben, sonst Merge-Konflikt im selben Klassenbereich.
 - **Verworfen:** Alle vier hier dedupen — würde mit #7s Rewrite von `Option` kollidieren.
 
 ## E2 — Testplatzierung der „kein Verhaltenswechsel"-Garantie
+
 - **Offener Punkt:** Wie absichern, dass die Delegation nichts ändert?
 - **Entscheidung:** Bestehenden `test_as_result` um eine Metadaten-Assertion (`__name__`/`__doc__`) erweitern.
 - **Begründung:** Konvention (`CLAUDE.md`, Abschnitt *Tests*): Fälle zu bestehenden parametrisierten Tabellen hinzufügen statt Einzeltests. `functools.wraps` ist der einzige Bruchpunkt der Delegation, daher genau dort der Anker.
 - **Verworfen:** Neue eigenständige Testfunktion.
 
 ## E3 — `CONTEXT.md` bleibt unverändert
+
 - **Offener Punkt:** Muss das Glossar angepasst werden?
 - **Entscheidung:** Nein.
 - **Begründung:** Verhalten ist identisch; der Eintrag `as_result / from_fn` bleibt korrekt. Code ist Source of Truth, die Doku folgt nur bei Vertrags-/Verhaltensänderung (`CLAUDE.md`-Sync-Regel).

--- a/decisions/issue-5-remove-dead-option-errors.md
+++ b/decisions/issue-5-remove-dead-option-errors.md
@@ -1,28 +1,33 @@
 # Entscheidungs-Log — Issue #5 (Tote Option-Fehlerhierarchie entfernen)
 
 Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
 1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
-3. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default.
+2. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default.
 
 ## E1 — Löschen statt „`TransposeError` real machen"
+
 - **Offener Punkt:** Issue #5 bietet zwei Wege: tote Hierarchie löschen ODER `TransposeError` tatsächlich in `Option.transpose` werfen.
 - **Entscheidung:** Löschen (`OptionError` und `TransposeError` entfernt).
 - **Begründung:** (3) Rust-`Option::transpose` wirft keine dedizierte Transpose-Ausnahme — es liefert immer ein `Result`. (4) ponytail: Löschen vor Hinzufügen. Die Klassen sind nachweislich tot (`grep`: kein `raise` irgendwo). `CONTEXT.md` hält `TransposeError` bereits als „toten Begriff" fest.
 - **Verworfen:** `TransposeError` in den `case _`-Zweig von `transpose` einbauen — fügt nicht angefordertes Verhalten hinzu und weicht von Rust ab.
 
 ## E2 — README Zeile 11 (Feature-Liste)
+
 - **Offener Punkt:** Nur `TransposeError` streichen oder den ganzen „Error Handling"-Bullet umschreiben?
 - **Entscheidung:** Nur die `TransposeError`-Referenz entfernen, `UnwrapFailedError` behalten.
 - **Begründung:** `UnwrapFailedError` ist laut `CONTEXT.md` „die einzige tatsächlich geworfene Ausnahme" der Bibliothek — der Bullet bleibt damit wahr.
 - **Verworfen:** Ganzen Bullet löschen (würde eine korrekte Aussage mitentfernen).
 
 ## E3 — Reichweite der `CONTEXT.md`-Bereinigung
+
 - **Offener Punkt:** Neben den beiden Glossar-Einträgen referenzieren auch die Einträge `transpose` und `UnwrapFailedError` die gelöschten Klassen.
 - **Entscheidung:** Diese hängenden Erwähnungen ebenfalls bereinigt — innerhalb der „Fehlerhierarchie"-Ownership von #5. Die Verhaltens-Bullets des `transpose`-Eintrags bleiben unangetastet (Grenze zu #7 gewahrt).
 - **Begründung:** Vollständigkeit/Konvention: das Glossar darf keine nicht mehr existierenden Typen benennen (Code = Source of Truth).
 - **Verworfen:** Nur die zwei Haupteinträge entfernen und hängende Referenzen stehen lassen.
 
 ## E4 — Breaking Change explizit machen
+
 - **Offener Punkt:** Stillschweigend entfernen oder kennzeichnen?
 - **Entscheidung:** Entfernen exportierter Namen (`OptionError`, `TransposeError`) als Breaking Change im PR-Body für Release Notes vermerkt.
 - **Begründung:** Konvention: Eingriffe in die öffentliche API werden für Konsumenten sichtbar dokumentiert.

--- a/decisions/issue-6-remove-redundant-ne.md
+++ b/decisions/issue-6-remove-redundant-ne.md
@@ -1,21 +1,25 @@
 # Entscheidungs-Log — Issue #6 (Redundante `__ne__`-Overrides entfernen)
 
 Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
 1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
-3. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default.
+2. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default.
 
 ## E1 — Scope: nur `Ok` und `Err`
+
 - **Offener Punkt:** Issue #6 nennt drei `__ne__` (`Ok`, `Err`, `Option`); alle drei in diesem PR?
 - **Entscheidung:** Nur `Ok.__ne__` und `Err.__ne__` entfernen. `Option.__ne__` bleibt → wird von #7 mitentfernt.
 - **Begründung:** Maintainer-Re-Scoping; #7 fasst die `Option`-Klasse komplett neu. Disjunkte Code-Bereiche → konfliktfreie Parallel-PRs.
 - **Verworfen:** Alle drei hier — kollidiert mit #7s Rewrite von `Option`.
 
 ## E2 — Beweisbarkeit des „kein Verhaltenswechsel"
+
 - **Offener Punkt:** Ist die Löschung garantiert verhaltenserhaltend?
 - **Entscheidung:** Ja — beide `__eq__` liefern immer ein `bool` (nie `NotImplemented`), daher reproduziert Pythons auto-abgeleitetes `!=` exakt das alte `not self.__eq__(other)`.
 - **Begründung:** (2)/Python-Datenmodell seit Py3. Ein Tiebreaker über Rust war nicht nötig.
 
 ## E3 — Testplatzierung
+
 - **Offener Punkt:** Wo den Regressionstest ablegen und welchen Fall?
 - **Entscheidung:** Cross-Type-Fall `(Ok(1), Err(1), True)` in die bestehende `test__ne__`-Tabelle in `tests/results/test_result.py`.
 - **Begründung:** Konvention (parametrisierte Tabellen mit `ids=`). `test_option.py` gehört #7 — bewusst nicht angefasst, um Datei-Kollisionen zu vermeiden.

--- a/decisions/issue-7-seal-option-two-state.md
+++ b/decisions/issue-7-seal-option-two-state.md
@@ -1,45 +1,57 @@
 # Entscheidungs-Log — Issue #7 (Option als versiegelter Zwei-Zustands-Typ)
 
 Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
 1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
-3. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default.
+2. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default.
 
 ## E1 — `Some`/`Null` als `@final`-Subklassen statt Factory-Funktionen
+
 - **Offener Punkt:** Das Issue lässt offen, ob `Some`/`Null` echte Subklassen werden oder dünne Factories bleiben, die auf Subklassen delegieren.
 - **Entscheidung:** Echte `@final`-Subklassen von `Option[T]`: `Some[T]` (trägt `_value` im Slot) und `Null[T]` (slotlos, kein Wert).
 - **Begründung:** (1) `CLAUDE.md`-Architektur — Verhalten per Polymorphie, nie per Flag/`isinstance`; exakt das `Result`/`Ok`/`Err`-Muster. (3) Rust modelliert `Some`/`None` als Varianten. Ermöglicht direktes Pattern-Matching `case Some(v)` / `case Null()`.
 - **Verworfen:** Modul-Factory-Funktionen, die an Classmethods delegieren (das Alt-Muster) — hielten einen Konstruktionspfad für den Leerzustand offen und verkomplizieren `__match_args__`.
 
 ## E2 — `Option.some()` / `Option.none()` Classmethods behalten
+
 - **Offener Punkt:** Entfernen oder behalten?
 - **Entscheidung:** Als dünne Delegatoren an `Some`/`Null` behalten.
 - **Begründung:** (2) Bestehende öffentliche API; ponytail: minimaler Eingriff, kein zusätzlicher Bruch über den Issue-Scope hinaus.
 - **Verworfen:** Entfernen (unnötiger zweiter Breaking Change).
 
 ## E3 — Direkte Konstruktion des Leerzustands verhindern
+
 - **Offener Punkt:** Wie „make illegal states unrepresentable" technisch umsetzen?
 - **Entscheidung:** Basis `Option` = `abc.ABC` mit abstrakten Methoden → `Option()` wirft `TypeError`; kein öffentlicher `__init__`, der `None` als Leer-Sentinel speichert.
 - **Begründung:** Issue-Kern + `CONTEXT.md`-Invariante „`Result` selbst wird nie instanziiert". Abwesenheit ist nun strukturell (eigener Typ), nicht der Wert `None`.
 - **Verworfen:** Sentinel-basierte Einzelklasse (`_MISSING`-Objekt) — inspiziert weiterhin einen gespeicherten Wert, macht Abwesenheit nicht strukturell und widerspricht der vom Issue geforderten polymorphen Dispatch-Logik.
 
 ## E4 — `__match_args__`-Form
+
 - **Offener Punkt:** Pattern-Matching-Form unter dem neuen Design.
 - **Entscheidung:** `Some.__match_args__ = ("_value",)`, `Null.__match_args__ = ()`.
 - **Begründung:** `case Some(v)` bindet den Wert, `case Null()` matcht den Leerzustand ohne Bindung — Spiegel von Rusts `Some(v)` / `None`. Ersetzt das alte `case Option(content)` der Einzelklassen-Ära.
 - **Verworfen:** Weiter auf `_content` matchen.
 
 ## E5 — `transpose`-Semantik unter den neuen Semantiken
+
 - **Offener Punkt:** `Null()` ist nun von `Some(None)` verschieden — ändert das `Option.transpose`?
 - **Entscheidung:** Semantik unverändert: `Null() → Ok(Null())`, `Some(Ok(v)) → Ok(Some(v))`, `Some(Err(e)) → Err(e)`, sonst `Ok(Some(_))`. Umsetzung jetzt polymorph statt per `_content`-Match.
 - **Begründung:** (3) entspricht Rust-`transpose`; (1) `CONTEXT.md` `transpose`-Eintrag (dessen Text #5/Bestand bleibt). Kein Sonderfall für `Some(None)` nötig — der Leerzustand ist ohnehin ein eigener Typ.
 - **Verworfen:** Einen Sonderzweig für `Some(None)` einführen.
 
 ## E6 — Doku-Grenze zu #5
+
 - **Offener Punkt:** Sowohl #5 als auch #7 fassen `CONTEXT.md`/`CLAUDE.md` an.
 - **Entscheidung:** #7 ändert nur die Einträge `Option`/`Some`/`Null`/`unwrap_or`/`Cross-Conversion` + Beispieldialoge 1 & 2 bzw. die `Option`-Architektur- und Pattern-Matching-Absätze. `OptionError`/`TransposeError`/`transpose`-Einträge und der „Failure mode"-Satz bleiben #5.
 - **Begründung:** Disjunkte Zeilenbereiche → unabhängig mergebare PRs (Koordinations-Konvention).
 
 ## E7 — Breaking Change kennzeichnen
+>
+> **Nachtrag:** Die Festlegung `Some(None) != Null()` wurde später umgekehrt —
+> siehe [forbid-some-none.md](forbid-some-none.md). `Some(None)` ist nun verboten
+> und wirft `ValueError`.
+
 - **Offener Punkt:** Umfang der Verhaltensänderung.
 - **Entscheidung:** Major-Bump; im PR-Body als Breaking Change vermerkt: `Some(None) != Null()`, falsy-`Some(...)` nicht mehr als „abwesend" behandelt, `Option(...)` nicht mehr direkt konstruierbar.
 - **Begründung:** Konvention: sichtbare API-/Semantik-Brüche werden für Konsumenten dokumentiert.

--- a/prompts/seal-result-option.md
+++ b/prompts/seal-result-option.md
@@ -1,0 +1,114 @@
+# Prompt: `Result` und `Option` zu echten versiegelten Summentypen machen
+
+> Konsolidierter Arbeits-Prompt (Sealing der Basis + `Some(None)`-Verbot).
+> Quelle: iterative Prompt-Verbesserung; Stand vor `/compact`.
+
+## Ziel
+
+Make illegal states unrepresentable: Die einzigen bewohnbaren Varianten von
+`Result` sind `Ok` und `Err`, von `Option` sind es `Some` und `Null` — exakt zwei
+je Typ. Eine dritte Variante darf weder zur Laufzeit noch laut Typechecker
+existieren. Zusätzlich gilt: `Some` umschließt immer einen echten Wert `T`,
+niemals `None`.
+
+## Problem heute (`src/results/results.py`)
+
+- `Result`/`Option` sind offene `abc.ABC`. `Ok/Err/Some/Null` sind zwar `@final`,
+  aber die Basis selbst ist nicht versiegelt: externer Code kann `class X(Result)`
+  mit eigener Implementierung definieren und so eine dritte, ungültige Variante
+  erzeugen → illegaler Zustand ist repräsentierbar.
+- `Some(None)` ist konstruierbar; `Some.__init__` stellt den Wert ungeprüft ab.
+- Der Klassen-Docstring von `Option` (Zeilen ~311–319) behauptet sogar fälschlich,
+  `Some(None)` sei „a legal, present state distinct from `Null()`". Das ist falsch
+  und kodifiziert den Bug als Feature.
+
+## Kernanforderung 1: die Basis versiegeln (Laufzeit + Typecheck)
+
+- `@final` auf der abstrakten Basis ist KEIN Weg: `typing.final` ist nur
+  Typechecker-Advisory UND würde die internen Varianten `Ok/Err` selbst verbieten
+  (genau der Widerspruch „abstrakt + final").
+- Versiegele zur Laufzeit über `__init_subclass__` auf `Result` bzw. `Option`:
+  jede Subklasse, die nicht in diesem Modul definiert ist, wirft `TypeError`. Das
+  deckt auch indirektes Erben (`class X(Ok)`) ab, da der Guard für den ganzen
+  Teilbaum feuert.
+- `Ok/Err/Some/Null` bleiben öffentlich — Pattern-Matching (`case Ok(v)`),
+  `isinstance` und Importe hängen daran.
+
+## Kernanforderung 2: `Some(None)` verbieten
+
+`Some` umschließt immer einen echten Wert `T`; `None` ist ausschließlich das
+Absenz-Sentinel und wird allein durch `Null` repräsentiert. `Some(None)` ist damit
+verboten und darf nicht konstruierbar sein — genau dafür existiert `Option`.
+
+- FALSCH und zu korrigieren: der `Option`-Docstring (Zeilen ~311–319). Aussage
+  entfernen und umkehren.
+- Durchsetzen an der Konstruktionsgrenze (`Some.__init__` bzw. `Option.some()`):
+  `None` wird abgewiesen.
+- `from_fn`/`as_option` sind bereits konform (sie mappen `None` → `Null`, bauen also
+  nie `Some(None)`); diese Pfade bleiben unverändert.
+
+## Offene Designentscheidungen (autonom fällen, im Decision-Log festhalten)
+
+### A. Versiegelungs-Mechanik
+
+- **A) `__init_subclass__`-Versiegelung, Varianten bleiben öffentlich** — laziest,
+  ein Guard pro Basis. **[Empfehlung]**
+- B) private genestete Varianten + Smart-Constructor-Factories — nur, wenn es über
+  A hinaus echten Mehrwert gibt; Pattern-Matching/Importe müssen weiter über
+  öffentliche Namen laufen.
+
+### B. Verhalten an der Some-Grenze bei `None`
+
+- **A) hart abweisen: `Some(None)` wirft.** **[Empfehlung — entspricht „verboten"]**
+- B) normalisieren: `None` kollabiert überall zu `Null()` (konsistent mit
+  from_fn/as_option).
+- Eine Regel wählen und überall gleich anwenden.
+
+### C. Folge für `Some.map`/`transpose`
+
+`Some(5).map(lambda _: None)` und `Some(Ok(None)).transpose()` laufen über die
+Some-Grenze. Bei A werfen sie, bei B werden sie zu `Null` — bewusst festlegen,
+nicht dem Zufall überlassen.
+
+### D. Fehlertyp bei „werfen"
+
+`ValueError` (laziest) oder ein dedizierter `OptionError` (passend zum
+`ResultError`-Muster). Hinweis: `OptionError`/`TransposeError` werden in CLAUDE.md
+erwähnt, existieren im Code aber NICHT — also neu anlegen oder die stale Doku
+mitkorrigieren.
+
+## Falls Factories (nur bei Mechanik B)
+
+`Result.ok()`/`err()` sind bereits Instanzmethoden (→ `Option`). Ein Factory
+`Result.ok(value)` kollidiert damit. Nutze die Modul-Klassen `Ok`/`Err` als
+Konstruktoren oder einen anderen Factory-Namen. `Option.some()/none()` existieren
+schon.
+
+## Grenzen
+
+- Typecheck-Grenze: „T ist nicht None" lässt sich mit PEP-695-Generics nicht sauber
+  ausdrücken — Durchsetzung ist Laufzeit-only (Decke per `ponytail:`-Kommentar
+  benennen).
+
+## Verifikation & Abschluss
+
+- Negativtest in `tests/results/`: eine Subklasse von `Result`/`Option` außerhalb
+  des Moduls muss `TypeError` werfen (parametrisiert, mit `ids=`).
+- Negativtest: `Some(None)` / `Option.some(None)` muss je nach Entscheidung werfen
+  (A) bzw. `Null()` ergeben (B); als parametrisierter Fall mit `ids=`.
+- Den falschen `Some(None)`-Doctest/Docstring in `Option` korrigieren.
+- Stale Doctests, die `Result.Ok(...)` referenzieren, an die reale API angleichen.
+- `uv run pytest`, `uv run mypy src tests`, `uv run ruff check` grün; Working Tree
+  clean.
+- CONTEXT.md (Begriff „versiegelter Summentyp"/„Variante") und die
+  Architecture-Notiz in CLAUDE.md aktualisieren; Entscheidung im Decision-Log.
+
+## Verifizierte Code-Fakten (Stand dieser Session)
+
+- `Option` ist bereits ABC mit `@final` `Some`/`Null` — CLAUDE.md beschreibt noch
+  die alte Single-Class-`_content`-Variante (stale).
+- `OptionError`/`TransposeError` existieren im Code nicht (nur in CLAUDE.md).
+- `Result`-Basis ist nicht versiegelt; externes Erben möglich.
+- `ok()`/`err()` sind Instanzmethoden (→ `Option`) — Namenskollision mit Factories.
+- `Some(None)` ist heute konstruierbar; der `Option`-Docstring behauptet das sei
+  legal.

--- a/src/results/results.py
+++ b/src/results/results.py
@@ -314,10 +314,14 @@ class Option[T](abc.ABC):
     """
     `Option` is a sealed two-state type: a value is either present ([`Some`]) or
     absent ([`Null`]). Absence is encoded in the *type* (a separate [`Null`]
-    variant), never in a stored sentinel value, so `Some(None)` is a legal,
-    present state distinct from `Null()`. Behavior is selected by polymorphic
-    dispatch on the two `@final` variants; the base class is abstract and cannot
-    be instantiated directly.
+    variant), never in a stored sentinel value, and `None` is solely the absence
+    sentinel, represented only by `Null()`. `Some(None)` is therefore forbidden
+    and raises `ValueError` — as does any path that would wrap `None`
+    (`map`/`transpose` producing `None`, `Ok(None).ok()`). Use `Null()` for an
+    absent value, and `and_then` (`T -> Option[U]`) rather than `map` (`T -> U`)
+    when a step may be absent. Behavior is selected by polymorphic dispatch on
+    the two `@final` variants; the base class is abstract and cannot be
+    instantiated directly.
     """
 
     @staticmethod
@@ -614,6 +618,11 @@ class Some[T](Option[T]):
     __match_args__ = ("_value",)
 
     def __init__(self, value: T) -> None:
+        # ponytail: None is absence, not a value — use Null() for absence and
+        # and_then (T -> Option[U]) over map (T -> U). Runtime-only: PEP 695
+        # generics can't express "T is not None".
+        if value is None:
+            raise ValueError("Some(None) is forbidden; use Null() for absence")
         self._value = value
 
     def __str__(self) -> str:
@@ -695,7 +704,7 @@ class Null[T](Option[T]):
     __match_args__ = ()
 
     def __str__(self) -> str:
-        return f"{None}"
+        return "None"
 
     def __repr__(self) -> str:
         return "Null()"

--- a/tests/results/test_option.py
+++ b/tests/results/test_option.py
@@ -268,7 +268,6 @@ def test_or_else_when_null_should_call_the_given_function_or_return_the_some_val
         (Some(0), 0),
         (Some(""), ""),
         (Some([]), []),
-        (Some(None), None),
     ],
     ids=[
         "test_iter_when_some_with_int_should_yield_int",
@@ -277,7 +276,6 @@ def test_or_else_when_null_should_call_the_given_function_or_return_the_some_val
         "test_iter_when_some_with_zero_should_yield_zero",
         "test_iter_when_some_with_empty_str_should_yield_empty_str",
         "test_iter_when_some_with_empty_list_should_yield_empty_list",
-        "test_iter_when_some_with_none_should_yield_none",
     ],
 )
 def test_iter(option, expected):
@@ -291,7 +289,6 @@ def test_iter(option, expected):
         (Null(), "Null()"),
         (Some("test"), "Some('test')"),
         (Null(), "Null()"),
-        (Some(None), "Some(None)"),
         (Some(0), "Some(0)"),
     ],
     ids=[
@@ -299,7 +296,6 @@ def test_iter(option, expected):
         "test_repr_when_null_with_none_should_return_formatted_string",
         "test_repr_when_some_with_str_should_return_formatted_string",
         "test_repr_when_null_with_str_should_return_formatted_string",
-        "test_repr_when_some_none_should_return_some_none_not_null",
         "test_repr_when_some_zero_should_return_some_zero",
     ],
 )
@@ -310,6 +306,19 @@ def test_repr(option, expected):
 def test_str_when_some_should_return_value_string() -> None:
     assert str(Some(10)) == "10"
     assert str(Null()) == "None"
+
+
+def test_some_none_is_forbidden() -> None:
+    # None is absence, not a value: Some(None) raises, as do paths that would
+    # wrap None (map -> None, transpose). Use Null() / and_then instead.
+    with pytest.raises(ValueError, match="Some.None. is forbidden"):
+        Some(None)
+    with pytest.raises(ValueError, match="Some.None. is forbidden"):
+        Option.some(None)
+    with pytest.raises(ValueError, match="Some.None. is forbidden"):
+        Some(5).map(lambda _: None)
+    with pytest.raises(ValueError, match="Some.None. is forbidden"):
+        Some(Ok(None)).transpose()
 
 
 def test_option_base_class_cannot_be_instantiated_directly() -> None:
@@ -323,13 +332,11 @@ def test_option_base_class_cannot_be_instantiated_directly() -> None:
         ({Some(1), Null(), Some(1), Null()}, 2),
         ({Some(1), Some(2)}, 2),
         ({Some("a"), Null()}, 2),
-        ({Some(None), Null(), Some(None), Null()}, 2),
     ],
     ids=[
         "test_hash_when_some_and_no_duplicates_should_return_correct_length",
         "test_hash_when_different_some_values_should_return_correct_length",
         "test_hash_when_some_and_null_strings_should_return_correct_length",
-        "test_hash_when_some_none_and_null_should_remain_distinct_members",
     ],
 )
 def test_hash(options, expected) -> None:
@@ -346,8 +353,6 @@ def test_hash(options, expected) -> None:
         (Some(10), Null(), False),
         (Some(10), Some(20), False),
         (Null(), Null(), True),
-        (Some(None), Null(), False),
-        (Some(None), Some(None), True),
         (Some(0), Null(), False),
         (Some(""), Null(), False),
     ],
@@ -359,8 +364,6 @@ def test_hash(options, expected) -> None:
         "test_eq_when_some_and_null_with_same_int_should_return_false",
         "test_eq_when_some_with_different_int_should_return_false",
         "test_eq_when_null_with_different_values_should_return_true",
-        "test_eq_when_some_none_and_null_should_return_false",
-        "test_eq_when_both_some_none_should_return_true",
         "test_eq_when_some_zero_and_null_should_return_false",
         "test_eq_when_some_empty_str_and_null_should_return_false",
     ],
@@ -378,7 +381,6 @@ def test_eq(option1, option2, expected):
         (Null(), Null(), False),
         (Some(10), Null(), True),
         (Some(10), Some(20), True),
-        (Some(None), Null(), True),
         (Some(0), Null(), True),
     ],
     ids=[
@@ -388,7 +390,6 @@ def test_eq(option1, option2, expected):
         "test_ne_when_null_with_same_str_should_return_false",
         "test_ne_when_some_and_null_with_same_int_should_return_true",
         "test_ne_when_some_with_different_int_should_return_true",
-        "test_ne_when_some_none_and_null_should_return_true",
         "test_ne_when_some_zero_and_null_should_return_true",
     ],
 )
@@ -435,7 +436,6 @@ def test_unwrap_when_null_should_raise_error() -> None:
         (Some(0), 42, 0),
         (Some(""), "x", ""),
         (Some([]), [1], []),
-        (Some(None), 42, None),
     ],
     ids=[
         "test_unwrap_or_when_some_should_return_value",
@@ -443,7 +443,6 @@ def test_unwrap_when_null_should_raise_error() -> None:
         "test_unwrap_or_when_some_zero_should_return_zero_not_default",
         "test_unwrap_or_when_some_empty_str_should_return_empty_str_not_default",
         "test_unwrap_or_when_some_empty_list_should_return_empty_list_not_default",
-        "test_unwrap_or_when_some_none_should_return_none_not_default",
     ],
 )
 def test_unwrap_or_when_some_value_should_return_value_or_provided_default(
@@ -459,14 +458,12 @@ def test_unwrap_or_when_some_value_should_return_value_or_provided_default(
         (Null(), lambda: 3, 3),
         (Some(0), lambda: 3, 0),
         (Some(""), lambda: "x", ""),
-        (Some(None), lambda: 3, None),
     ],
     ids=[
         "test_unwrap_or_else_when_some_should_return_value",
         "test_unwrap_or_else_when_null_should_call_func_and_return_value",
         "test_unwrap_or_else_when_some_zero_should_return_zero_not_func",
         "test_unwrap_or_else_when_some_empty_str_should_return_empty_str_not_func",
-        "test_unwrap_or_else_when_some_none_should_return_none_not_func",
     ],
 )
 def test_unwrap_or_else_when_some_value_should_return_value_or_compute_from_function(
@@ -499,14 +496,12 @@ def test_or_else_when_some_should_return_some(option, func, expected):
     [
         (Some(Ok(5)), Ok(Some(5))),
         (Some(Err("error")), Err("error")),
-        (Some(Ok(None)), Ok(Some(None))),
         (Null(), Ok(Null())),
         (Some(5), Ok(Some(5))),
     ],
     ids=[
         "transpose_when_some_ok_should_return_ok_with_some_value",
         "transpose_when_some_err_should_return_err",
-        "transpose_when_some_ok_none_should_return_ok_with_some_none",
         "transpose_when_null_should_return_ok_with_null",
         "transpose_when_some_value_should_return_ok_some_value",
     ],

--- a/tests/results/test_pattern_matching.py
+++ b/tests/results/test_pattern_matching.py
@@ -22,15 +22,3 @@ def test_pattern_matching_on_null_type() -> None:
             reached = True
 
     assert reached
-
-
-def test_pattern_matching_distinguishes_some_none_from_null() -> None:
-    o = Some(None)
-    match o:
-        case Null():
-            branch = "null"
-        case Some(value):
-            branch = "some"
-
-    assert branch == "some"
-    assert value is None

--- a/tests/results/test_result.py
+++ b/tests/results/test_result.py
@@ -119,6 +119,18 @@ def test_ok(result, expected):
     assert result.ok() == expected
 
 
+def test_ok_when_ok_none_is_forbidden() -> None:
+    # Ok(None).ok() would build Some(None), which is forbidden.
+    with pytest.raises(ValueError, match="Some.None. is forbidden"):
+        Ok(None).ok()
+
+
+def test_err_when_err_none_is_forbidden() -> None:
+    # Err(None).err() would build Some(None), which is forbidden.
+    with pytest.raises(ValueError, match="Some.None. is forbidden"):
+        Err(None).err()
+
+
 @pytest.mark.parametrize(
     "result, expected",
     [


### PR DESCRIPTION
## Was

`Some(None)` ist jetzt **verboten** und wirft `ValueError`. `None` ist ausschließlich das Absenz-Sentinel und wird allein durch `Null()` repräsentiert — „vorhanden, aber `None`" gibt es nicht mehr.

Der Guard sitzt an **einer** Stelle (`Some.__init__`); jeder Pfad, der `None` in ein `Some` packen würde, erbt die Ablehnung ohne Sonderzweige:
- `Some(None)` / `Option.some(None)`
- `Some(x).map(lambda _: None)`
- `Some(Ok(None)).transpose()`
- `Ok(None).ok()` / `Err(None).err()`

Faustregel: für einen optionalen Schritt `and_then` (`T -> Option[U]`) statt `map` (`T -> U`); für Abwesenheit `Null()`.

## Designentscheidungen

- **Hart werfen (A), nicht normalisieren (B).** `map` ist `T -> U`; ein optionales Zwischenergebnis gehört in `and_then`. `Some(None)` ist damit ein Programmierfehler und scheitert laut. B hätte `cast("Some[T]", Null())` erzwungen — ein Cast, der den Typechecker ruhigstellt statt das Design zu stützen.
- **`ValueError`**, kein neuer Fehlertyp: eine Konstruktions-Präconditionsverletzung (idiomatisch in Python), bewusst getrennt von der `UnwrapFailedError`-Hierarchie (Laufzeit-Wertbehandlung). Dokumentiert in [`decisions/forbid-some-none.md`](decisions/forbid-some-none.md).

Kehrt die `#7`-Festlegung `Some(None) != Null()` um (Querverweis im `#7`-Log ergänzt).

## Mitgenommen

- `Null.__str__`: `f"{None}"` → `"None"` (Cleanup, verhaltensgleich).

## ⚠️ Breaking Change

`Some(None)` und jeder Pfad, der es konstruieren würde, werfen nun `ValueError` statt ein vorhandenes `Option` zu liefern. Major-Bump. Falsy-Werte ungleich `None` (`Some(0)`, `Some("")`, `Some([])`) bleiben unverändert **vorhanden**.

## Doku & Tests

- `Option`-Docstring, `CLAUDE.md`, 9 `CONTEXT.md`-Stellen (inkl. `UnwrapFailedError`-Eintrag) umgestellt.
- `Some(None)`-Zeilen aus den Parametrize-Tabellen entfernt (würden bei der Collection werfen); stattdessen `test_some_none_is_forbidden`, `test_ok_when_ok_none_is_forbidden`, `test_err_when_err_none_is_forbidden` (alle mit `match=`).

## Verifikation

`uv run pytest` (150 passed) · `uv run mypy src tests` · `uv run ruff check` · `uv run ruff format --check` — alle grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)