### PR TITLE
refactor: Ok.is_err_and — replace self-predicate dispatch with polymorphic constant (return False)

### DIFF
--- a/docs/decisions/issue-21-ok-is-err-and-constant.md
+++ b/docs/decisions/issue-21-ok-is-err-and-constant.md
@@ -1,0 +1,46 @@
+# Decision Log — Issue #21 (`Ok.is_err_and`: replace self-predicate dispatch with `return False`)
+
+## Context
+
+`Ok.is_err_and` previously read:
+
+```python
+def is_err_and[E](self, fn: Callable[[E], bool]) -> bool:
+    return not self.is_ok()
+```
+
+This is the only variant method in the `Result` family whose body calls another
+predicate on `self` instead of returning a flat polymorphic constant.
+
+## Decision
+
+Replace the body with:
+
+```python
+def is_err_and[E](self, fn: Callable[[E], bool]) -> bool:
+    return False
+```
+
+## Rationale
+
+**D1 — Polymorphism over self-predicate dispatch.** `CLAUDE.md` and `CONTEXT.md`
+require that behavior be selected by *variant identity* (the type), never by
+querying `self` with another predicate inside the method body. `return not
+self.is_ok()` is an indirect flag check: it calls `is_ok()` (which is
+`Literal[True]` on `Ok`) just to negate it. The constant `return False`
+expresses the same invariant directly and is consistent with the sibling
+`Err.is_ok_and`, which already returns `False` directly.
+
+**D2 — Behavior-neutral.** `Ok.is_ok()` is typed `Literal[True]`, so
+`not self.is_ok()` is always `False`. The predicate `fn` is never called before
+or after the change. No observable behavior differs for any caller.
+
+**D3 — Predicate non-invocation is now explicitly specified.** Three new
+parametrized cases in `test_is_err_and` use `lambda _: 1/0` as the predicate.
+If the predicate were ever called, the test would raise `ZeroDivisionError` and
+fail immediately. The cases cover an `int`, a falsy `int` (`0`), and an empty
+`str` — confirming the rule holds for all `Ok` values, not just truthy ones.
+
+**D4 — Scope boundary.** Only `Ok.is_err_and` is touched. The abstract stub on
+`Result` and `Err.is_err_and` are unchanged. Annotation kept as `-> bool`
+(not narrowed to `Literal[False]`) to match the sibling.

--- a/src/results/results.py
+++ b/src/results/results.py
@@ -179,7 +179,7 @@ class Ok[T](Result[T, Any]):
         return False
 
     def is_err_and[E](self, fn: Callable[[E], bool]) -> bool:
-        return not self.is_ok()
+        return False
 
     def is_ok(self) -> Literal[True]:
         return True

--- a/tests/results/test_result.py
+++ b/tests/results/test_result.py
@@ -93,11 +93,17 @@ def test_is_ok_and(result, predicate, expected):
         (Err(2), lambda x: x > 1, True),
         (Err(0), lambda x: x > 1, False),
         (Ok("Something went wrong"), lambda x: x > 1, False),
+        (Ok(42), lambda _: 1 / 0, False),
+        (Ok(0), lambda _: 1 / 0, False),
+        (Ok(""), lambda _: 1 / 0, False),
     ],
     ids=[
         "is_err_and when Err value matches predicate should return True",
         "is_err_and when Err value does not match predicate should return False",
         "is_err_and when Ok value should return False",
+        "is_err_and when Ok predicate must not be called (int value)",
+        "is_err_and when Ok predicate must not be called (falsy int)",
+        "is_err_and when Ok predicate must not be called (empty string)",
     ],
 )
 def test_is_err_and(result, predicate, expected):


### PR DESCRIPTION
## Summary

- Replaces `return not self.is_ok()` in `Ok.is_err_and` with `return False` — a one-line, behavior-neutral change that aligns with the codebase invariant: variant behavior is selected by *polymorphism*, never by calling a self-predicate inside a method body.
- Adds three parametrized test cases with `lambda _: 1/0` predicates to explicitly specify that the predicate is never invoked on an `Ok` variant (covers truthy int, falsy int `0`, and empty string `""`).
- Adds `docs/decisions/issue-21-ok-is-err-and-constant.md` explaining why the constant beats self-predicate dispatch.

## Test plan

- [ ] `uv run pytest` — 153 passed
- [ ] `uv run mypy src tests` — no issues found in 7 source files
- [ ] `uv run ruff check` — all checks passed
- [ ] `uv run ruff format --check` — all files already formatted
- [ ] `graphify update .` — graph rebuilt (364 nodes, 597 edges)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)