### PR TITLE
fix: drop redundant __cause__ assignment in Err.unwrap (#22)

### DIFF
--- a/docs/decisions/issue-22-err-unwrap-drop-cause.md
+++ b/docs/decisions/issue-22-err-unwrap-drop-cause.md
@@ -1,0 +1,34 @@
+# Entscheidungs-Log — Issue #22 (Redundante `__cause__`-Zuweisung in `Err.unwrap` entfernen)
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Python-Datenmodell (`raise ... from`) · 4. ponytail-Default (laziest funktionierend).
+
+## E1 — Warum `exc.__cause__ = self._inner_value` toter Code ist
+
+- **Offener Punkt:** Ist die explizite Zuweisung wirklich redundant, oder gibt es einen Seiteneffekt?
+- **Entscheidung:** Redundant. `raise exc from self._inner_value` setzt per Python-Datenmodell (PEP 3134) sowohl `exc.__cause__ = self._inner_value` als auch `exc.__suppress_context__ = True` — beides atomar, bevor der Frame abgewickelt wird. Die vorangegangene manuelle Zuweisung überschreibt dasselbe Attribut unmittelbar danach mit identischem Wert.
+- **Begründung:** CPython-Quellcode (`ceval.c`, `_PyException_SetCause`) und PEP 3134 sind eindeutig. Kein Interpreter-spezifisches Verhalten; Standard Python ≥3.0.
+- **Verworfen:** Zeile beibehalten „zur Klarheit" — widerspricht ponytail und schafft falsche Suggestion, dass `raise ... from` allein nicht ausreicht.
+
+## E2 — Scope: nur die eine Zeile
+
+- **Offener Punkt:** Soll die `isinstance`-Branch zu `match/case` umgebaut werden?
+- **Entscheidung:** Nein. Nur `exc.__cause__ = self._inner_value` löschen. Beide `raise`-Anweisungen und der `isinstance`-Check bleiben unberührt.
+- **Begründung:** Issue #22 ist ausdrücklich auf diese eine Zeile beschränkt. Strukturumbau ist Scope-Creep; parallele Issues (#21 u. a.) arbeiten in Nachbarklassen. Ponytail-Prinzip: kürzeste Änderung, die das Problem löst.
+- **Verworfen:** Konvertierung zu `match`-Statement, Inlining der `isinstance`-Prüfung.
+
+## E3 — Testabsicherung vor der Löschung
+
+- **Offener Punkt:** Der bestehende `test_unwrap_err`-Fall prüfte nur die Fehlermeldung (`match=`), nicht `__cause__`. Wo und wie die Invariante verankern?
+- **Entscheidung:** Bestehende `test_unwrap_err`-Parametrisierungstabelle umstrukturieren: Parameter `expected_cause` (entweder das konkrete Exception-Objekt oder `None`) hinzugefügt; Testfunktion prüft nach dem `pytest.raises`-Block `excinfo.value.__cause__ is expected_cause`. Kein neuer Testfunktionsname.
+- **Begründung:** Konvention (`CLAUDE.md`, Abschnitt *Tests*): Fälle zu bestehenden parametrisierten Tabellen mit `ids=` hinzufügen. TDD-Reihenfolge: Test zuerst grün, dann Löschung — bestätigt, dass die Verhaltensgarantie vor und nach der Änderung gilt.
+- **Verworfen:** Neue eigenständige Testfunktion.
+
+## E4 — `CONTEXT.md` bleibt unverändert
+
+- **Offener Punkt:** Muss das Glossar angepasst werden?
+- **Entscheidung:** Nein.
+- **Begründung:** Der öffentliche Vertrag (`Err.unwrap` kettet `BaseException`-Werte via `__cause__`) ist identisch. Nur die interne Implementierung verliert eine überflüssige Zeile. Code ist Source of Truth; die Doku folgt nur bei Vertrags-/Verhaltensänderung (`CLAUDE.md`-Sync-Regel).
+- **Verworfen:** Glossar anfassen (kein Vertragsbruch, kein Sync notwendig).

--- a/src/results/results.py
+++ b/src/results/results.py
@@ -296,7 +296,6 @@ class Err[E](Result[Any, E]):
             self.UNWRAP_ERROR_MESSAGE % ("unwrap", repr(self._inner_value)),
         )
         if isinstance(self._inner_value, BaseException):
-            exc.__cause__ = self._inner_value
             raise exc from self._inner_value
         raise exc
 

--- a/tests/results/test_result.py
+++ b/tests/results/test_result.py
@@ -265,26 +265,22 @@ def test_unwrap_ok(result, expected):
     assert result.unwrap() == expected
 
 
+_exc_for_cause = ValueError("Error message")
+
 @pytest.mark.parametrize(
-    "result, expected",
+    "result, match, expected_cause",
     [
         (
             Err("Emergency failure"),
-            pytest.raises(
-                UnwrapFailedError,
-                match=re.escape(
-                    "Called `.unwrap` on an [`Err`] value: 'Emergency failure'"
-                ),
-            ),
+            re.escape("Called `.unwrap` on an [`Err`] value: 'Emergency failure'"),
+            None,
         ),
         (
-            Err(ValueError("Error message")),
-            pytest.raises(
-                UnwrapFailedError,
-                match=re.escape(
-                    "Called `.unwrap` on an [`Err`] value: ValueError('Error message'"
-                ),
+            Err(_exc_for_cause),
+            re.escape(
+                "Called `.unwrap` on an [`Err`] value: ValueError('Error message'"
             ),
+            _exc_for_cause,
         ),
     ],
     ids=[
@@ -292,9 +288,10 @@ def test_unwrap_ok(result, expected):
         "unwrap when Err value should raise UnwrapFailedError with exception",
     ],
 )
-def test_unwrap_err(result, expected):
-    with expected:
+def test_unwrap_err(result, match, expected_cause):
+    with pytest.raises(UnwrapFailedError, match=match) as excinfo:
         result.unwrap()
+    assert excinfo.value.__cause__ is expected_cause
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Removes the redundant `exc.__cause__ = self._inner_value` line in `Err.unwrap`; `raise exc from self._inner_value` (PEP 3134) already sets both `__cause__` and `__suppress_context__` atomically, making the manual assignment dead code
- Extends the existing `test_unwrap_err` parametrized table with an `expected_cause` column, pinning both the exception-chaining path (`__cause__ is exc`) and the non-exception path (`__cause__ is None`)
- Adds decision log at `docs/decisions/issue-22-err-unwrap-drop-cause.md`

## Test plan

- [x] `uv run pytest` — 150 passed
- [x] `uv run mypy src tests` — no issues
- [x] `uv run ruff check` — all checks passed
- [x] `graphify update .` — graph rebuilt (365 nodes, 599 edges)
- [x] Working tree clean; public API and CONTEXT.md unchanged

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)