### PR TITLE
feat(option): add is_none_or and inspect (#17)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -120,6 +120,28 @@ Die abwesende Variante von `Option`; `@final`-Subklasse ohne gespeicherten Wert.
 (`Null("Error")`, `Null(10)`) sind fehlerhaft: `Null` nimmt keine Parameter und
 würde mit `TypeError` scheitern.
 
+### is_none_or / inspect
+
+Zwei `Option`-Methoden für **nicht-transformierende** Interaktion mit dem
+enthaltenen Wert:
+
+- `is_none_or(fn)` — gibt `True` zurück, wenn die Option `Null` ist, oder wenn
+  sie `Some(v)` ist und `fn(v)` wahr ergibt. Komplement zu `is_some_and`:
+  `Null()` → immer `True`; `Some(v)` → `fn(v)`.
+- `inspect(fn)` — ruft `fn(v)` auf (ausschließlich für Nebeneffekte wie Logging
+  oder Debugging), wenn die Option `Some(v)` ist, und gibt **dasselbe Objekt**
+  zurück (`result is self`). Für `Null` ist es ein No-op. Der Rückgabewert von
+  `fn` wird ignoriert.
+
+Beide Methoden sind polymorphisch implementiert (`@abc.abstractmethod` auf `Option`,
+je eine Implementierung auf `Some` und `Null`); kein `isinstance`- oder
+`_value is None`-Check im Körper. `inspect` erzeugt keine neuen Wrapper — weder
+`Some(...)` noch `Null()` — und kann deshalb auch nie `Some(None)` erzeugen.
+
+*Avoid:* `inspect` mit `map` verwechseln. `map` transformiert und gibt einen
+**neuen** Container zurück; `inspect` gibt `self` zurück und ist für reine
+Nebeneffekte gedacht.
+
 ### unwrap
 
 Oberbegriff für den **wert-entpackenden Zugriff** auf der „guten" Seite:

--- a/docs/decisions/issue-17-option-is-none-or-inspect.md
+++ b/docs/decisions/issue-17-option-is-none-or-inspect.md
@@ -1,0 +1,76 @@
+# Entscheidungs-Log — Issue #17 (Option: `is_none_or` / `inspect`)
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Option`-Semantik (std) · 4. ponytail-Default.
+
+Lane O: ausschließlich `src/results/option.py`, zugehöriger Testmodul und CONTEXT.md
+(Anker `### Null`). Kein `results.py`-Diff.
+
+## E1 — Methoden-Platzierung: alphabetisch innerhalb beider Klassen
+
+- **Offener Punkt:** Wo genau landen `inspect` und `is_none_or` in der
+  Methodenreihenfolge von `Some` und `Null`?
+- **Entscheidung:** Alphabetisch nach den unmittelbaren Geschwistern:
+  `inspect` nach `filter` (f < i); `is_none_or` nach `is_none`, vor `is_some`
+  (lexikographisch `is_none_or` < `is_some`). Dasselbe Muster in `Some` und `Null`.
+- **Begründung:** (2) Bestehende Konvention — alle Methoden innerhalb der Klassen
+  sind alphabetisch geordnet.
+- **Verworfen:** Neue Methoden ans Ende hängen (würde die Ordnung brechen).
+
+## E2 — Signatur `inspect`: `Callable[[T], object]` statt `Callable[[T], Any]`
+
+- **Offener Punkt:** `Any` (wie Rust's `FnOnce(T)`) oder `object`?
+- **Entscheidung:** `Callable[[T], object]` — der Rückgabewert wird nie genutzt;
+  `object` drückt das mit der breitestmöglichen statischen Typ-Einschränkung aus
+  (jede callable ist hier gültig).
+- **Begründung:** (4) ponytail: `object` ist restriktiver als `Any` und
+  signalisiert „Rückgabewert egal, nicht genutzt".
+- **Verworfen:** `Callable[[T], Any]` (weniger präzise für die Intention).
+
+## E3 — `is_none_or` auf `Null`: `Literal[True]` Rückgabetyp
+
+- **Offener Punkt:** `bool` oder `Literal[True]`?
+- **Entscheidung:** `Literal[True]` — spiegelt `is_none()` und `is_some_and()` auf
+  `Null`, die ebenfalls Literal-Typen zurückgeben (`Literal[True]` bzw.
+  `Literal[False]`).
+- **Begründung:** (2) Konsistenz mit den Geschwistern `is_none`, `is_some`,
+  `is_some_and` auf denselben konkreten Klassen.
+- **Verworfen:** `bool` (weniger präzise, inkonsistent mit Geschwistern).
+
+## E4 — `inspect` gibt `self` zurück (kein neues Objekt)
+
+- **Offener Punkt:** Darf `inspect` ein neues `Some`/`Null` bauen?
+- **Entscheidung:** Nein. Beide Implementierungen geben `self` zurück; der Test
+  `assert o.inspect(fn) is o` erzwingt Objektidentität.
+- **Begründung:** (3) Rust-Semantik: `Option::inspect` gibt `self` zurück. (1)
+  Invariante: kein öffentlicher Pfad darf einen ungültigen Zustand erzeugen; da
+  `self` unveränderlich ist, ist Identität die sicherste Rückgabe. `Some(None)`
+  kann dadurch nicht entstehen.
+- **Verworfen:** `Some(self._value)` oder `Null()` als neue Instanzen (unnötig,
+  würde Identitätstest brechen).
+
+## E5 — Keine `None`-Prüfung in den Implementierungskörpern
+
+- **Offener Punkt:** Soll `inspect` sicherstellen, dass `fn` kein `None`
+  zurückgibt?
+- **Entscheidung:** Nein. `inspect` verwirft den Rückgabewert; es entsteht kein
+  Wrapper. Kein `if result is None: raise ValueError(...)`.
+- **Begründung:** (1) Aufgabenstellung: „Add NO None checks." `Some(None)` kann
+  nicht entstehen, weil `inspect` den Rückgabewert von `fn` schlicht ignoriert.
+
+## E6 — TDD: Failing Tests vor der Implementierung
+
+- **Vorgehen:** Alle neuen Testfälle wurden in `tests/results/test_option.py` als
+  zusätzliche parametrized-Einträge und zwei eigenständige Testfunktionen
+  (Identitäts-Pin, Side-Effect-Recorder) eingefügt, **bevor** die Implementierung
+  in `option.py` erfolgte. Sechs rote Fehler bestätigt, dann alle 174 grün.
+
+## E7 — CONTEXT.md: ein neuer Abschnitt, lokalisiert am `### Null`-Anker
+
+- **Offener Punkt:** Wo in CONTEXT.md einfügen?
+- **Entscheidung:** Unmittelbar nach `### Null`, vor `### unwrap`. Kein anderer
+  CONTEXT.md-Abschnitt berührt.
+- **Begründung:** (1) Aufgabenstellung: Anker `### Null`. (2) Disjunktheit: Lane
+  #14 editiert den Bereich nach `### map` — kein Konflikt.

--- a/src/results/option.py
+++ b/src/results/option.py
@@ -128,26 +128,19 @@ class Option[T](abc.ABC):
         """
 
     @abc.abstractmethod
-    def is_some(self) -> bool:
+    def inspect(self, fn: Callable[[T], object]) -> Option[T]:
         """
-        Returns `true` if the option is a [`Some`] value.
+        Calls `fn` with the contained value if [`Some`], returns `self` unchanged.
+        If [`Null`], does nothing and returns `self`. The return value of `fn` is
+        discarded; `inspect` is called purely for side effects (e.g. logging).
 
         # Examples:
 
-        >>> assert not Null().is_some()
-        >>> assert Some(10).is_some()
-        """
-
-    @abc.abstractmethod
-    def is_some_and(self, op: Callable[[T], bool]) -> bool:
-        """
-        Returns `true` if the option is a [`Some`] and the value inside of it matches a predicate.
-
-        # Examples:
-
-        >>> assert Some(10).is_some_and(is_even)
-        >>> assert not Some(15).is_some_and(is_even)
-        >>> assert not Null().is_some_and(is_even)
+        >>> log = []
+        >>> assert Some(10).inspect(log.append) == Some(10)
+        >>> assert log == [10]
+        >>> assert Null().inspect(log.append) == Null()
+        >>> assert log == [10]  # unchanged
         """
 
     @abc.abstractmethod
@@ -159,6 +152,19 @@ class Option[T](abc.ABC):
 
         >>> assert Null().is_none()
         >>> assert not Some(10).is_none()
+        """
+
+    @abc.abstractmethod
+    def is_none_or(self, fn: Callable[[T], bool]) -> bool:
+        """
+        Returns `true` if the option is [`Null`], or if it is [`Some`] and the
+        value inside matches the predicate `fn`. The complement of `is_some_and`.
+
+        # Examples:
+
+        >>> assert Null().is_none_or(is_even)
+        >>> assert Some(10).is_none_or(is_even)
+        >>> assert not Some(15).is_none_or(is_even)
         """
 
     @abc.abstractmethod
@@ -348,14 +354,21 @@ class Some[T](Option[T]):
     def filter(self, predicate: Callable[[T], bool]) -> Option[T]:
         return self if predicate(self._value) else Null()
 
+    def inspect(self, fn: Callable[[T], object]) -> Option[T]:
+        fn(self._value)
+        return self
+
+    def is_none(self) -> Literal[False]:
+        return False
+
+    def is_none_or(self, fn: Callable[[T], bool]) -> bool:
+        return fn(self._value)
+
     def is_some(self) -> Literal[True]:
         return True
 
     def is_some_and(self, op: Callable[[T], bool]) -> bool:
         return op(self._value)
-
-    def is_none(self) -> Literal[False]:
-        return False
 
     def map[U](self, op: Callable[[T], U]) -> Option[U]:
         return Some(op(self._value))
@@ -439,14 +452,20 @@ class Null[T](Option[T]):
     def filter(self, predicate: Callable[[T], bool]) -> Option[T]:
         return self
 
+    def inspect(self, fn: Callable[[T], object]) -> Option[T]:
+        return self
+
+    def is_none(self) -> Literal[True]:
+        return True
+
+    def is_none_or(self, fn: Callable[[T], bool]) -> Literal[True]:
+        return True
+
     def is_some(self) -> Literal[False]:
         return False
 
     def is_some_and(self, op: Callable[[T], bool]) -> Literal[False]:
         return False
-
-    def is_none(self) -> Literal[True]:
-        return True
 
     def map[U](self, op: Callable[[T], U]) -> Option[U]:
         return Null()

--- a/tests/results/test_option.py
+++ b/tests/results/test_option.py
@@ -133,6 +133,60 @@ def test_is_some_and_when_some_value_should_match_predicate(
 
 
 @pytest.mark.parametrize(
+    "option, predicate, expected",
+    [
+        (Null(), lambda x: x % 2 == 0, True),
+        (Some(10), lambda x: x % 2 == 0, True),
+        (Some(15), lambda x: x % 2 == 0, False),
+    ],
+    ids=[
+        "test_is_none_or_when_null_should_return_true",
+        "test_is_none_or_when_some_and_predicate_true_should_return_true",
+        "test_is_none_or_when_some_and_predicate_false_should_return_false",
+    ],
+)
+def test_is_none_or_when_null_returns_true_and_some_defers_to_predicate(
+    option, predicate, expected
+) -> None:
+    assert option.is_none_or(predicate) == expected
+
+
+def test_inspect_runs_fn_only_on_some_and_returns_self() -> None:
+    calls: list[int] = []
+    fn = lambda v: calls.append(v)  # noqa: E731
+
+    some = Some(42)
+    result = some.inspect(fn)
+    assert result is some
+    assert calls == [42]
+
+    calls.clear()
+    null: Option = Null()
+    result_null = null.inspect(fn)
+    assert result_null is null
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    "option, expected_calls",
+    [
+        (Some(7), [7]),
+        (Null(), []),
+    ],
+    ids=[
+        "test_inspect_when_some_should_call_fn_with_value",
+        "test_inspect_when_null_should_not_call_fn",
+    ],
+)
+def test_inspect_when_called_should_side_effect_on_some_and_noop_on_null(
+    option, expected_calls
+) -> None:
+    calls: list[int] = []
+    option.inspect(lambda v: calls.append(v))
+    assert calls == expected_calls
+
+
+@pytest.mark.parametrize(
     "option, func, expected",
     [
         (Some(10), lambda i: i * 2, Some(20)),


### PR DESCRIPTION
## Summary

- Adds `Option.is_none_or(fn)` — returns `True` for `Null`, or `fn(v)` for `Some(v)`. The complement of the existing `is_some_and`.
- Adds `Option.inspect(fn)` — calls `fn` for side effects on `Some(v)`, no-op on `Null`, returns the identical object (`assert o.inspect(fn) is o`).
- Both implemented with polymorphic dispatch only: `@abc.abstractmethod` stub on `Option` base, one concrete impl each on `Some` and `Null`. No `isinstance`, no `_value is None`, no truthiness checks.

## Changed files (Lane O — disjoint from Lane #14)

- `src/results/option.py` — method stubs + `Some`/`Null` implementations
- `tests/results/test_option.py` — TDD-first: failing parametrized tests added before implementation
- `CONTEXT.md` — new `### is_none_or / inspect` section immediately after `### Null`
- `docs/decisions/issue-17-option-is-none-or-inspect.md` — decision log

## Test plan

- [x] Red-first: 6 failing tests confirmed before implementation
- [x] `uv run pytest` — 174 passed
- [x] `uv run mypy src tests` — no issues in 9 source files
- [x] `uv run ruff check` — all checks passed
- [x] `graphify update .` — graph rebuilt (416 nodes, 725 edges)
- [x] `inspect` identity test: `assert o.inspect(fn) is o` (both `Some` and `Null`)
- [x] `is_none_or` predicate-false case included (not vacuous)

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)