### PR TITLE
feat: add inspect / inspect_err to Result (#14)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -165,6 +165,23 @@ zurück, ohne die fehler-/leerseitige Variante anzufassen: `Result.map` wirkt au
 *Avoid:* `map` mit `and_then` verwechseln. Gibt deine Funktion bereits ein
 `Result`/`Option` zurück, erzeugt `map` eine **doppelte** Verschachtelung.
 
+### inspect / inspect_err
+
+Seiteneffekt-Inspektoren, die den Container **unverändert** zurückgeben:
+`Result.inspect(fn)` ruft `fn` mit dem `Ok`-Wert auf (Nebeneffekt) und gibt
+`self` zurück; bei `Err` ist es ein No-op. `Result.inspect_err(fn)` spiegelt
+das: `fn` wird mit dem `Err`-Wert aufgerufen, bei `Ok` kein Aufruf.
+
+- Invariante: Rückgabe ist **dasselbe Objekt** (`inspect(fn) is self`) — kein
+  neuer Container, keine Transformation. Der Rückgabewert von `fn` wird
+  verworfen.
+- Verwendungszweck: Logging, Metriken, Debuggen in einer Methodenkette, ohne
+  den Datenfluss zu unterbrechen.
+
+*Avoid:* `inspect` mit `map` verwechseln. `map` **transformiert** den Wert und
+erzeugt einen neuen Container; `inspect` lässt den Container unangetastet und
+dient allein dem Nebeneffekt.
+
 ### and_then
 
 Verkettet eine Folgeoperation, die selbst wieder ein `Result`/`Option` liefert

--- a/docs/decisions/issue-14-result-inspect.md
+++ b/docs/decisions/issue-14-result-inspect.md
@@ -1,0 +1,76 @@
+# Entscheidungs-Log — Issue #14 (Result: add inspect / inspect_err)
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default.
+
+Zwei seiteneffektbehaftete Inspektoren — `inspect` / `inspect_err` — für die
+`Result`-Familie (`src/results/results.py`). Keine Verhaltensänderung an
+bestehenden Methoden, kein Berühren von `option.py` (disjunkter Lane #17).
+
+## E1 — Kein neuer Typparameter in `inspect` / `inspect_err` nötig
+
+- **Offener Punkt:** Sollen die Methoden mit einem eigenen Typparameter `[U]`
+  o. ä. parametrisiert werden, wie `map[U]` es tut?
+- **Entscheidung:** Keine neuen Typparameter. `inspect(fn: Callable[[T], Any])`
+  und `inspect_err(fn: Callable[[E], Any])` verwenden `Any` für den Rückgabetyp
+  von `fn` — genau wie Rusts `FnOnce(T)` ohne Rückgabewert; der Rückgabewert
+  wird verworfen.
+- **Begründung:** (4) ponytail/minimaler Diff: ein Typparameter wäre nur nötig,
+  wenn der Rückgabewert von `fn` in den Container einginge. Das tut er nicht —
+  `inspect` gibt `self` zurück. PEP 695 `def inspect[U](...)` wäre totes Gewicht.
+- **Verworfen:** `def inspect[U](self, fn: Callable[[T], U]) -> Result[T, E]`.
+
+## E2 — Rückgabetyp-Annotation auf der inerten Variante
+
+- **Offener Punkt:** Die inerte Variante (z. B. `Ok.inspect_err`) gibt `self`
+  zurück; ihr Rückgabetyp trägt einen „losen" Typparameter (`Result[T, E]` bzw.
+  `Result[Any, E]`). Muss das präzisiert werden?
+- **Entscheidung:** Die inerten Varianten folgen dem bestehenden Muster analoger
+  Methoden: `Ok.inspect_err` deklariert `def inspect_err[E](...) -> Result[T, E]`
+  (Typparameter für `E` nötig, weil `Ok[T]` kein `E` kennt), `Err.inspect`
+  entsprechend `def inspect[T](...) -> Result[T, E]`. Das ist byte-ident mit der
+  Signatur von `Err.map` und `Ok.map_err`.
+- **Begründung:** (2) Konventionstreue: bestehende inerte Varianten verwenden
+  denselben Trick (freier Typparameter in der Methode, damit die Signatur auf der
+  ABC-Basis passt). Ein abweichendes Muster würde ohne Mehrwert Inkonsistenz
+  erzeugen.
+
+## E3 — Alphabetische Einordnung (placement)
+
+- **Offener Punkt:** Wo in der Methodenliste werden `inspect` / `inspect_err`
+  eingefügt — vor oder nach `is_*`-Methoden?
+- **Entscheidung:** Einordnung unmittelbar **nach** `is_ok_and` und **vor**
+  `map` — alphabetisch: `inspect` < `is_*` … nein; tatsächlich `i` < `m`, und
+  `inspect` < `is_err` alphabetisch nicht. Da `is_err` < `inspect_err` < `map`
+  und `inspect` < `is_err`, wird `inspect` / `inspect_err` direkt nach dem
+  `is_ok_and`-Block gesetzt, unmittelbar vor `map`. Das entspricht dem
+  Positionierungsprinzip der Geschwistermethoden.
+- **Begründung:** (2) Konsistenz mit der bestehenden Reihenfolge; ein Bruch der
+  Reihenfolge erschwert das Auffinden.
+
+## E4 — No-op auf der inerten Variante: kein `isinstance`, kein Guard
+
+- **Offener Punkt:** Könnte die inerte Variante aus Sicherheitsgründen einen
+  `isinstance`-Check einbauen?
+- **Entscheidung:** Nein. Die inerte Variante gibt ausschließlich `return self`
+  zurück. Kein Check, kein Sentinel-Vergleich.
+- **Begründung:** (1) CLAUDE.md/CONTEXT.md-Invariante: Verhalten wird
+  ausschließlich durch **Polymorphie** ausgewählt. `inspect` verpackt nichts
+  und gibt `self` zurück — der `Some(None)`-Guard (in `Some.__init__`,
+  `option.py`) ist nicht involviert. Kein neuer Zustand, keine neue Grenze.
+- **Verworfen:** Guard-Check in der inerten Variante.
+
+## E5 — Doku-Synchronisation
+
+- **Offener Punkt:** Welche Doku-Dateien berührt diese Änderung?
+- **Entscheidung:** (a) `CONTEXT.md` erhält einen neuen Glossar-Abschnitt
+  `### inspect / inspect_err` unmittelbar nach `### map`. (b) Ein
+  Entscheidungs-Log wird unter `docs/decisions/issue-14-result-inspect.md`
+  abgelegt. (c) `CLAUDE.md` wird **nicht** geändert — es pflegt keine
+  Per-Methoden-Liste, und die Verträge der bestehenden Abschnitte ändern sich
+  nicht.
+- **Begründung:** (1) CLAUDE.md-Anweisung: CONTEXT.md ist das maßgebliche
+  Glossar; Code ist die Source of Truth, Glossar folgt. CLAUDE.md beschreibt
+  die Architektur, keine Methodenliste.

--- a/src/results/results.py
+++ b/src/results/results.py
@@ -98,6 +98,18 @@ class Result[T, E](abc.ABC):
         """Returns `True` if the result is an [`Ok`] and the value inside of it matches a predicate."""
 
     @abc.abstractmethod
+    def inspect(self, fn: Callable[[T], Any]) -> Result[T, E]:
+        """Calls `fn` with the contained value if [`Ok`], then returns `self` unchanged.
+        If [`Err`], returns `self` without calling `fn`.
+        """
+
+    @abc.abstractmethod
+    def inspect_err(self, fn: Callable[[E], Any]) -> Result[T, E]:
+        """Calls `fn` with the contained error if [`Err`], then returns `self` unchanged.
+        If [`Ok`], returns `self` without calling `fn`.
+        """
+
+    @abc.abstractmethod
     def map[U](self, fn: Callable[[T], U]) -> Result[U, E]:
         """Maps a `Result<T, E>` to `Result<U, E>` by applying a function to a contained [`Ok`] value,
         leaving an [`Err`] value untouched.
@@ -192,6 +204,13 @@ class Ok[T](Result[T, Any]):
     def is_ok_and(self, fn: Callable[[T], bool]) -> bool:
         return fn(self._inner_value)
 
+    def inspect(self, fn: Callable[[T], Any]) -> Result[T, Any]:
+        fn(self._inner_value)
+        return self
+
+    def inspect_err[E](self, fn: Callable[[E], Any]) -> Result[T, E]:
+        return self
+
     def map[U, E](self, fn: Callable[[T], U]) -> Result[U, E]:
         return Ok(fn(self._inner_value))
 
@@ -273,6 +292,13 @@ class Err[E](Result[Any, E]):
 
     def is_ok_and[T](self, fn: Callable[[T], bool]) -> bool:
         return False
+
+    def inspect[T](self, fn: Callable[[T], Any]) -> Result[T, E]:
+        return self
+
+    def inspect_err(self, fn: Callable[[E], Any]) -> Result[Any, E]:
+        fn(self._inner_value)
+        return self
 
     def map[T, U](self, fn: Callable[[T], U]) -> Result[U, E]:
         return self

--- a/tests/results/test_result.py
+++ b/tests/results/test_result.py
@@ -273,6 +273,7 @@ def test_unwrap_ok(result, expected):
 
 _exc_for_cause = ValueError("Error message")
 
+
 @pytest.mark.parametrize(
     "result, match, expected_cause",
     [
@@ -485,3 +486,39 @@ def test_hash():
 )
 def test__ne__(result, other, expected):
     assert (result != other) == expected
+
+
+@pytest.mark.parametrize(
+    "result, expected_calls, expected_identity",
+    [
+        (Ok(42), [42], True),
+        (Err("boom"), [], True),
+    ],
+    ids=[
+        "inspect when Ok value should call fn with value and return self",
+        "inspect when Err value should be no-op and return self",
+    ],
+)
+def test_inspect(result, expected_calls, expected_identity):
+    calls: list = []
+    returned = result.inspect(calls.append)
+    assert calls == expected_calls
+    assert (returned is result) == expected_identity
+
+
+@pytest.mark.parametrize(
+    "result, expected_calls, expected_identity",
+    [
+        (Ok(42), [], True),
+        (Err("boom"), ["boom"], True),
+    ],
+    ids=[
+        "inspect_err when Ok value should be no-op and return self",
+        "inspect_err when Err value should call fn with error and return self",
+    ],
+)
+def test_inspect_err(result, expected_calls, expected_identity):
+    calls: list = []
+    returned = result.inspect_err(calls.append)
+    assert calls == expected_calls
+    assert (returned is result) == expected_identity


### PR DESCRIPTION
## Summary

- Adds `Result.inspect(fn)` — calls `fn(value)` for its side effect if `Ok`, no-op if `Err`, returns `self` unchanged
- Adds `Result.inspect_err(fn)` — calls `fn(error)` for its side effect if `Err`, no-op if `Ok`, returns `self` unchanged
- Both implemented via `@abc.abstractmethod` stub on `Result` base + one concrete impl each on `Ok` and `Err`; pure polymorphic dispatch (no `isinstance`/flag/`is None` checks)

## Test plan

- [x] TDD red-first: parametrised tests added to `tests/results/test_result.py` before implementation
- [x] `inspect` runs `fn` only on `Ok`; `inspect_err` only on `Err` (call-recorder asserts `calls == [value]` vs `calls == []`)
- [x] Both variants assert identity: `result.inspect(fn) is result`
- [x] `uv run pytest` — 172 passed
- [x] `uv run mypy src tests` — no issues in 9 source files
- [x] `uv run ruff check` + `ruff format` — all checks passed, clean tree
- [x] `graphify update .` run — 417 nodes, 739 edges
- [x] Decision log: `docs/decisions/issue-14-result-inspect.md`
- [x] `CONTEXT.md`: new `### inspect / inspect_err` section inserted immediately after `### map`

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)