### PR TITLE
feat(option): add and_ / xor combinators (#18)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -142,6 +142,29 @@ je eine Implementierung auf `Some` und `Null`); kein `isinstance`- oder
 **neuen** Container zurück; `inspect` gibt `self` zurück und ist für reine
 Nebeneffekte gedacht.
 
+### and_ / xor
+
+Zwei `Option`-Methoden für **kombinatorische** Verknüpfung zweier Options:
+
+- `and_(optb)` — gibt `Null()` zurück, wenn `self` `Null` ist; andernfalls `optb`
+  (die andere Option unverändert). Das ist das **eager** Gegenstück zu `and_then`:
+  `optb` wird immer ausgewertet, unabhängig davon, ob `self` `Some` oder `Null` ist.
+  Verwende `and_then` (`T -> Option[U]`), wenn die Berechnung des nächsten Options
+  aufwändig ist oder den Wert von `self` benötigt.
+- `xor(optb)` — gibt `Some` zurück, wenn **genau eine** der beiden Options `Some`
+  ist; sonst `Null()`. Wahrheitstabelle: `Some.xor(Null) = Some(self)`,
+  `Null.xor(Some) = Some(optb)`, `Some.xor(Some) = Null()`, `Null.xor(Null) = Null()`.
+
+Beide Methoden sind polymorphisch implementiert (`@abc.abstractmethod` auf `Option`,
+je eine Implementierung auf `Some` und `Null`); kein `isinstance`-, `is None`- oder
+Truthiness-Check im Körper. `xor`'s Abhängigkeit von der Variante des Arguments wird
+via `optb.map_or(self, lambda _: Null())` aufgelöst — die Dispatch-Entscheidung liegt
+im `map_or` des Arguments, nicht in einem Flag-Check auf `self`.
+
+*Avoid:* `and_` mit `and_then` verwechseln. `and_` nimmt eine fertige Option entgegen
+(eager); `and_then` nimmt eine Funktion `T -> Option[U]` (lazy, hat Zugriff auf den
+`Some`-Wert). Beide geben `Null()` zurück, wenn `self` `Null` ist.
+
 ### unwrap
 
 Oberbegriff für den **wert-entpackenden Zugriff** auf der „guten" Seite:

--- a/docs/decisions/issue-18-option-and-xor.md
+++ b/docs/decisions/issue-18-option-and-xor.md
@@ -1,0 +1,71 @@
+# Entscheidungs-Log — Issue #18 (Option: `and_` / `xor`)
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Option`-Semantik (std) · 4. ponytail-Default.
+
+Lane O: ausschließlich `src/results/option.py`, zugehöriger Testmodul und CONTEXT.md
+(Anker `### is_none_or / inspect`). Kein `results.py`-Diff.
+
+## E1 — `and_`: Trailing-Underscore wegen Python-Keyword
+
+- **Offener Punkt:** Rust nennt die Methode `and`; Python reserviert `and` als
+  Schlüsselwort.
+- **Entscheidung:** `and_` (trailing underscore), analog zu `or_` im selben Modul.
+- **Begründung:** (2) Konvention im Projekt — `or_` ist bereits identisch benannt.
+  (3) Rust-Konvention bei Keyword-Konflikten.
+- **Verworfen:** `and_opt`, `and_option` (zu wortreich; Nachbarn heißen `or_`).
+
+## E2 — `and_`: `Some` gibt `optb` direkt zurück (Identität)
+
+- **Entscheidung:** `Some.and_(optb)` gibt `optb` direkt zurück — keine Kopie,
+  kein neuer Wrapper. `Some(1).and_(optb) is optb` gilt.
+- **Begründung:** (4) ponytail: das Einfachste, das korrekt ist. `optb` ist bereits
+  eine Option-Instanz; es gibt nichts zu wrappen. Identitäts-Pin im Test schreibt
+  das fest.
+
+## E3 — `xor` auf `Null`: gibt `optb` direkt zurück
+
+- **Entscheidung:** `Null.xor(optb)` gibt `optb` zurück — keine Inspektion von
+  `optb`'s Variante, kein Branch. `Null().xor(optb) is optb` gilt.
+- **Begründung:** (3) Rust-Semantik: `Null.xor` liefert `Some` iff `optb` `Some`
+  ist, sonst `Null` — das ist genau `optb` selbst. (4) ponytail: eine Zeile,
+  kein Branching.
+
+## E4 — `xor` auf `Some`: Dispatch via `optb.map_or` statt Flag-Check
+
+- **Offener Punkt:** `xor` muss auf beide Varianten von `optb` reagieren. Wie
+  ohne `isinstance`-Check?
+- **Entscheidung:** `Some.xor(optb)` → `optb.map_or(self, lambda _: Null())`.
+  `map_or` ruft `lambda _ : Null()` auf (→ `Null()`), wenn `optb` `Some` ist;
+  gibt `self` zurück (→ `self`), wenn `optb` `Null` ist. Keine Flag-Variable,
+  kein `isinstance`, kein `is None`.
+- **Begründung:** (1) Dispatch-Invariante: welche Variante vorliegt, entscheidet
+  die Polymorphie — hier die von `optb`. (4) ponytail: kürzeste korrekte Zeile.
+  Kommentiert mit `# ponytail:` im Code.
+- **Verworfen:** `if optb.is_none(): return self else: return Null()` (Truthiness-
+  äquivalent, bricht die Dispatch-Invariante).
+
+## E5 — Methoden-Platzierung: alphabetisch
+
+- **Entscheidung:** `and_` vor `and_then` (alphabetisch: `and_` < `and_then`);
+  `xor` nach `unwrap_or_else` (kein alphabetischer Geschwister nach `x`).
+  Identisch in `Option`-ABC, `Some` und `Null`.
+- **Begründung:** (2) Bestehende Konvention — alle Methoden sind alphabetisch
+  geordnet (siehe Issue #17).
+
+## E6 — TDD: Failing Tests vor der Implementierung
+
+- **Vorgehen:** Zehn neue Testfälle (vier für `and_`, vier für `xor`, zwei
+  Identitäts-Pins) als parametrized-Einträge in `tests/results/test_option.py`
+  eingefügt, **bevor** die Implementierung in `option.py` erfolgte. Zehn rote
+  Fehler bestätigt, dann alle 188 grün.
+
+## E7 — CONTEXT.md: neuer Abschnitt nach `### is_none_or / inspect`
+
+- **Offener Punkt:** Wo genau in CONTEXT.md?
+- **Entscheidung:** Unmittelbar nach `### is_none_or / inspect`, vor `### unwrap`.
+  Kein anderer CONTEXT.md-Abschnitt berührt.
+- **Begründung:** (1) Aufgabenstellung: Anker `### is_none_or / inspect`. (2)
+  Disjunktheit: nachgelagerte Abschnitte gehören zu anderen Lanes.

--- a/src/results/option.py
+++ b/src/results/option.py
@@ -81,6 +81,21 @@ class Option[T](abc.ABC):
         return Null()
 
     @abc.abstractmethod
+    def and_[U](self, optb: Option[U]) -> Option[U]:
+        """Returns [`Null`] if the option is [`Null`], otherwise returns `optb`.
+
+        This is the eager counterpart of [`and_then`]: the argument is evaluated
+        unconditionally. Use [`and_then`] when computing the next option is expensive.
+
+        # Examples:
+
+        >>> assert Some(1).and_(Some(2)) == Some(2)
+        >>> assert Some(1).and_(Null()) == Null()
+        >>> assert Null().and_(Some(2)) == Null()
+        >>> assert Null().and_(Null()) == Null()
+        """
+
+    @abc.abstractmethod
     def and_then[U](self, op: Callable[[T], Option[U]]) -> Option[U]:
         """Returns [`Null`] if the option is [`Null`], otherwise calls `op` with the
         wrapped value and returns the result.
@@ -316,6 +331,25 @@ class Option[T](abc.ABC):
         >>> assert Null().unwrap_or_else(lambda: 42) == 42
         """
 
+    @abc.abstractmethod
+    def xor(self, optb: Option[T]) -> Option[T]:
+        """Returns [`Some`] iff exactly one of `self` and `optb` is [`Some`].
+
+        Truth table::
+
+            Some(a).xor(Null())    == Some(a)
+            Null().xor(Some(b))    == Some(b)
+            Some(a).xor(Some(b))   == Null()
+            Null().xor(Null())     == Null()
+
+        # Examples:
+
+        >>> assert Some(1).xor(Null()) == Some(1)
+        >>> assert Null().xor(Some(2)) == Some(2)
+        >>> assert Some(1).xor(Some(2)) == Null()
+        >>> assert Null().xor(Null()) == Null()
+        """
+
 
 @final
 class Some[T](Option[T]):
@@ -344,6 +378,9 @@ class Some[T](Option[T]):
 
     def __iter__(self) -> Iterator[T]:
         yield self._value
+
+    def and_[U](self, optb: Option[U]) -> Option[U]:
+        return optb
 
     def and_then[U](self, op: Callable[[T], Option[U]]) -> Option[U]:
         return op(self._value)
@@ -419,6 +456,12 @@ class Some[T](Option[T]):
     def unwrap_or_else(self, op: Callable[[], T]) -> T:
         return self._value
 
+    def xor(self, optb: Option[T]) -> Option[T]:
+        # ponytail: xor's dependence on optb's variant is intrinsic and is resolved
+        # through optb's polymorphic dispatch, not a flag check — map_or returns
+        # `default` (self) when optb is Null and `op(v)` (Null()) when optb is Some.
+        return optb.map_or(self, lambda _: Null())
+
 
 @final
 class Null[T](Option[T]):
@@ -439,6 +482,9 @@ class Null[T](Option[T]):
 
     def __iter__(self) -> Iterator[None]:
         yield None
+
+    def and_[U](self, optb: Option[U]) -> Option[U]:
+        return Null()
 
     def and_then[U](self, op: Callable[[T], Option[U]]) -> Option[U]:
         return Null()
@@ -511,3 +557,6 @@ class Null[T](Option[T]):
 
     def unwrap_or_else(self, op: Callable[[], T]) -> T:
         return op()
+
+    def xor(self, optb: Option[T]) -> Option[T]:
+        return optb

--- a/tests/results/test_option.py
+++ b/tests/results/test_option.py
@@ -21,6 +21,58 @@ def sq_then_to_string(x: int) -> str | None:
 
 
 @pytest.mark.parametrize(
+    "option, optb, expected",
+    [
+        (Some(1), Some(2), Some(2)),
+        (Some(1), Null(), Null()),
+        (Null(), Some(2), Null()),
+        (Null(), Null(), Null()),
+    ],
+    ids=[
+        "test_and_when_some_and_some_should_return_optb",
+        "test_and_when_some_and_null_should_return_null",
+        "test_and_when_null_and_some_should_return_null",
+        "test_and_when_null_and_null_should_return_null",
+    ],
+)
+def test_and_when_called_should_return_optb_if_some_else_null(
+    option: Option, optb: Option, expected: Option
+) -> None:
+    assert option.and_(optb) == expected
+
+
+def test_and_some_returns_same_optb_instance() -> None:
+    optb: Option = Some(99)
+    assert Some(1).and_(optb) is optb
+
+
+@pytest.mark.parametrize(
+    "option1, option2, expected",
+    [
+        (Some(1), Null(), Some(1)),
+        (Null(), Some(2), Some(2)),
+        (Some(1), Some(2), Null()),
+        (Null(), Null(), Null()),
+    ],
+    ids=[
+        "test_xor_when_some_and_null_should_return_self",
+        "test_xor_when_null_and_some_should_return_optb",
+        "test_xor_when_both_some_should_return_null",
+        "test_xor_when_both_null_should_return_null",
+    ],
+)
+def test_xor_when_called_should_return_some_iff_exactly_one_is_some(
+    option1: Option, option2: Option, expected: Option
+) -> None:
+    assert option1.xor(option2) == expected
+
+
+def test_xor_null_returns_same_optb_instance() -> None:
+    optb: Option = Some(42)
+    assert Null().xor(optb) is optb
+
+
+@pytest.mark.parametrize(
     "option, func, expected",
     [
         (Some(2), sq_then_to_string, Some("4")),


### PR DESCRIPTION
## Summary

- Add `Option.and_(optb)` — eager counterpart of `and_then`: returns `optb` when `self` is `Some`, otherwise `Null()`. Argument is evaluated unconditionally.
- Add `Option.xor(optb)` — returns `Some` iff exactly one of `self`/`optb` is `Some`, else `Null()`.
- Both implemented via pure polymorphic dispatch (`@abc.abstractmethod` stub + one `Some` impl + one `Null` impl); no `isinstance`, `is None`, or truthiness checks anywhere.
- `Some.xor` resolves `optb`'s variant through `optb.map_or(self, lambda _: Null())` — the dispatch decision lives in `optb`, not in a flag on `self`.

## Test plan

- [ ] Parametrized table for `and_`: all four receiver/argument combinations (Some×Some, Some×Null, Null×Some, Null×Null) — confirmed red before implementation, green after.
- [ ] Parametrized table for `xor`: all four truth-table combinations — same TDD cycle.
- [ ] Identity pin: `Some(1).and_(optb) is optb` and `Null().xor(optb) is optb` — verifies no wrapping occurs.
- [ ] `uv run pytest` — 188 passed.
- [ ] `uv run mypy src tests` — clean.
- [ ] `uv run ruff check` / `ruff format` — clean, no reformatting.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)