### PR TITLE
feat(result): add eager and_ / or_ combinators (#15)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -204,6 +204,32 @@ das: `fn` wird mit dem `Err`-Wert aufgerufen, bei `Ok` kein Aufruf.
 erzeugt einen neuen Container; `inspect` lässt den Container unangetastet und
 dient allein dem Nebeneffekt.
 
+### `and_` / `or_`
+
+Zwei **eager** (eifrige) Kombinatoren, die einen vorhandenen `Result`-Wert
+kombinieren — im Gegensatz zu `and_then`/`or_else`, die eine Funktion übergeben
+und den Aufruf aufschieben:
+
+- `and_(res)` — gibt `res` zurück, wenn `self` `Ok` ist; gibt `self` zurück,
+  wenn `self` `Err` ist. Die übergebene `Err`-Seite von `self` propagiert direkt.
+- `or_(res)` — gibt `self` zurück, wenn `self` `Ok` ist; gibt `res` zurück,
+  wenn `self` `Err` ist. Der übergebene Wert tritt nur in Kraft, wenn `self`
+  ein Fehler war.
+
+Beide Methoden sind polymorphisch implementiert (`@abc.abstractmethod` auf `Result`,
+je eine Implementierung auf `Ok` und `Err`); kein `isinstance`- oder Flag-Check im
+Körper. Die **inerte** Variante gibt stets `self` zurück (kein neuer Container).
+
+- `Ok.or_(res) is self` — `Ok` bleibt unangetastet.
+- `Err.and_(res) is self` — der ursprüngliche Fehler wird weitergereicht.
+
+Unterschied zu `and_then`/`or_else`: Letztere bekommen eine **Callable** und führen
+sie lazy aus; `and_`/`or_` bekommen einen fertig ausgewerteten `Result`-Wert.
+
+*Avoid:* annehmen, `and_`/`or_` verhielten sich wie das Python-Schlüsselwort
+`and`/`or` (Short-Circuit auf Wahrheitswert). Sie operieren auf `Result`-Varianten
+per Polymorphie und ignorieren jegliche Wahrheitswert-Semantik des enthaltenen Werts.
+
 ### and_then
 
 Verkettet eine Folgeoperation, die selbst wieder ein `Result`/`Option` liefert

--- a/docs/decisions/issue-15-result-and-or.md
+++ b/docs/decisions/issue-15-result-and-or.md
@@ -1,0 +1,63 @@
+# Entscheidungs-Log — Issue #15 (Result: add eager and_ / or_ combinators)
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default.
+
+Zwei eager Kombinatoren — `and_` / `or_` — für die `Result`-Familie
+(`src/results/results.py`). Keine Verhaltensänderung an bestehenden Methoden,
+kein Berühren von `option.py` (disjunkter Lane #17).
+
+## E1 — Benennung: Trailing Underscore statt Alias
+
+- **Offener Punkt:** `and`/`or` sind Python-Schlüsselwörter; wie heißen die Methoden?
+- **Entscheidung:** `and_` und `or_` (trailing underscore) — identisch mit Rusts
+  `Result::and` / `Result::or`, nur um den Namenskonflikt umgangen.
+- **Begründung:** (3) Rust-Semantik: dies ist die kanonische Rust-Konvention für
+  Methoden, deren Name ein reserviertes Wort wäre. Keine Alias-Lösung nötig.
+- **Verworfen:** `result_and`, `combine`, `chain`.
+
+## E2 — Keine neuen Typparameter auf der inerten Variante nötig
+
+- **Offener Punkt:** Welche Typparameter brauchen `Ok.or_` und `Err.and_`, die
+  `self` zurückgeben?
+- **Entscheidung:** Die inerten Varianten folgen dem bestehenden Muster analoger
+  Methoden. `Ok.or_` deklariert `def or_[E, F](self, res: Result[T, F]) ->
+  Result[T, F]` (freie Typparameter `E`, `F`); `Err.and_` entsprechend
+  `def and_[T, U](self, res: Result[U, E]) -> Result[U, E]`.
+- **Begründung:** (2) Konventionstreue: dasselbe Muster nutzen `Ok.inspect_err`
+  und `Err.inspect` — freier Typparameter in der Methode, damit die Signatur auf
+  der ABC-Basis passt.
+
+## E3 — Rückgabe des bestehenden Objekts (keine Rekonstruktion)
+
+- **Offener Punkt:** Sollen `Ok.or_` und `Err.and_` `self` oder ein neu
+  konstruiertes Objekt zurückgeben?
+- **Entscheidung:** `return self` — das bestehende Objekt wird unverändert
+  zurückgegeben, kein `Ok(self._inner_value)` o. ä.
+- **Begründung:** (4) ponytail/minimaler Diff: eine Rekonstruktion wäre
+  überflüssige Arbeit, die die Identitäts-Invariante (`is`-Test) brechen würde.
+  Die Methode nimmt auch nichts Neues ein — sie gibt `self` direkt durch.
+- **Verworfen:** `return Ok(self._inner_value)` in `Ok.or_`.
+
+## E4 — Alphabetische Einordnung (placement)
+
+- **Offener Punkt:** Wo in der Methodenliste werden `and_` / `or_` eingefügt?
+- **Entscheidung:** `and_` unmittelbar **vor** `and_then` (alphabetisch: `and_`
+  < `and_then`); `or_` unmittelbar **vor** `or_else`. Gilt für ABC, `Ok` und
+  `Err` gleichermaßen.
+- **Begründung:** (2) Konsistenz mit dem bestehenden Ordnungsprinzip; eager/lazy-
+  Paare liegen direkt nebeneinander, was die Dokumentations-Signalwirkung stärkt.
+
+## E5 — Doku-Synchronisation
+
+- **Offener Punkt:** Welche Doku-Dateien berührt diese Änderung?
+- **Entscheidung:** (a) `CONTEXT.md` erhält einen neuen Glossar-Abschnitt
+  `### \`and_\` / \`or_\`` unmittelbar nach `### inspect / inspect_err` und vor
+  `### and_then`. (b) Ein Entscheidungs-Log wird unter
+  `docs/decisions/issue-15-result-and-or.md` abgelegt. (c) `CLAUDE.md` wird
+  **nicht** geändert — es pflegt keine Per-Methoden-Liste.
+- **Begründung:** (1) CLAUDE.md-Anweisung: CONTEXT.md ist das maßgebliche
+  Glossar; Code ist die Source of Truth, Glossar folgt. CLAUDE.md beschreibt
+  die Architektur, keine Methodenliste.

--- a/src/results/results.py
+++ b/src/results/results.py
@@ -25,6 +25,14 @@ class Result[T, E](abc.ABC):
     """
 
     @abc.abstractmethod
+    def and_[U](self, res: Result[U, E]) -> Result[U, E]:
+        """Returns `res` if the result is [`Ok`], otherwise returns the [`Err`] value of `self`.
+
+        Eager counterpart of `and_then` (which takes a callable). Unlike `and_then`,
+        `res` is always evaluated before the call.
+        """
+
+    @abc.abstractmethod
     def and_then[U](self, op: Callable[[T], Result[U, E]]) -> Result[U, E]:
         """Calls `op` if the result is [`Ok`], otherwise returns the [`Err`] value of `self`.
         # Examples:
@@ -134,6 +142,14 @@ class Result[T, E](abc.ABC):
         """Converts from `Result<T, E>` to [`Option<T>`]."""
 
     @abc.abstractmethod
+    def or_[F](self, res: Result[T, F]) -> Result[T, F]:
+        """Returns `self` if the result is [`Ok`], otherwise returns `res`.
+
+        Eager counterpart of `or_else` (which takes a callable). Unlike `or_else`,
+        `res` is always evaluated before the call.
+        """
+
+    @abc.abstractmethod
     def or_else(self, op: Callable[[E], Result[T, E]]) -> Result[T, E]:
         """Returns the result if it is [`Ok`], otherwise calls `op` with the wrapped error and returns the result."""
 
@@ -179,6 +195,9 @@ class Ok[T](Result[T, Any]):
 
     def __init__(self, inner_value: T) -> None:
         self._inner_value = inner_value
+
+    def and_[U, E](self, res: Result[U, E]) -> Result[U, E]:
+        return res
 
     def and_then[U, E](self, op: Callable[[T], Result[U, E]]) -> Result[U, E]:
         return op(self._inner_value)
@@ -230,6 +249,9 @@ class Ok[T](Result[T, Any]):
     def ok(self) -> Option[T]:
         return Some(self._inner_value)
 
+    def or_[E, F](self, res: Result[T, F]) -> Result[T, F]:
+        return self
+
     def or_else[E](self, op: Callable[[E], Result[T, E]]) -> Result[T, E]:
         return Ok(self._inner_value)
 
@@ -268,6 +290,9 @@ class Err[E](Result[Any, E]):
 
     def __init__(self, inner_value: E) -> None:
         self._inner_value = inner_value
+
+    def and_[T, U](self, res: Result[U, E]) -> Result[U, E]:
+        return self
 
     def and_then[T, U](self, op: Callable[[T], Result[U, E]]) -> Result[U, E]:
         return self
@@ -318,6 +343,9 @@ class Err[E](Result[Any, E]):
 
     def ok(self) -> Option[Any]:
         return Null()
+
+    def or_[T, F](self, res: Result[T, F]) -> Result[T, F]:
+        return res
 
     def or_else[T](self, op: Callable[[E], Result[T, E]]) -> Result[T, E]:
         return op(self._inner_value)

--- a/tests/results/test_result.py
+++ b/tests/results/test_result.py
@@ -522,3 +522,49 @@ def test_inspect_err(result, expected_calls, expected_identity):
     returned = result.inspect_err(calls.append)
     assert calls == expected_calls
     assert (returned is result) == expected_identity
+
+
+@pytest.mark.parametrize(
+    "result, res, expected",
+    [
+        (Ok(2), Ok(3), Ok(3)),
+        (Ok(2), Err("late"), Err("late")),
+        (Err("early"), Ok(3), Err("early")),
+        (Err("early"), Err("late"), Err("early")),
+    ],
+    ids=[
+        "and_ when Ok and Ok should return second Ok",
+        "and_ when Ok and Err should return Err",
+        "and_ when Err and Ok should return original Err",
+        "and_ when Err and Err should return original Err",
+    ],
+)
+def test_and_(result, res, expected):
+    assert result.and_(res) == expected
+
+
+@pytest.mark.parametrize(
+    "result, res, expected",
+    [
+        (Ok(2), Ok(3), Ok(2)),
+        (Ok(2), Err("fallback"), Ok(2)),
+        (Err("e"), Ok(3), Ok(3)),
+        (Err("e"), Err("fallback"), Err("fallback")),
+    ],
+    ids=[
+        "or_ when Ok and Ok should return original Ok",
+        "or_ when Ok and Err should return original Ok",
+        "or_ when Err and Ok should return Ok",
+        "or_ when Err and Err should return second Err",
+    ],
+)
+def test_or_(result, res, expected):
+    assert result.or_(res) == expected
+
+
+def test_and_or_identity() -> None:
+    """Ok.or_ and Err.and_ return the original instance (no reconstruction)."""
+    ok = Ok(1)
+    e = Err("e")
+    assert ok.or_(Err("other")) is ok
+    assert e.and_(Ok(99)) is e


### PR DESCRIPTION
## Summary

- Add `Result.and_(res)`: returns `res` when `Ok`, returns `self` (the original error) when `Err` — eager counterpart of `and_then`.
- Add `Result.or_(res)`: returns `self` when `Ok`, returns `res` when `Err` — eager counterpart of `or_else`.
- Both use pure polymorphic dispatch (`@abc.abstractmethod` on `Result`, one concrete impl each on `Ok` and `Err`); no `isinstance` / flag / sentinel checks anywhere.
- `Ok.or_` and `Err.and_` return the existing instance (`is` identity pinned by test).

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)