### PR TITLE
feat(result): add transpose (Result[Option] -> Option[Result]) (#16)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -286,13 +286,27 @@ Zielfamilie; das Original wird nicht verändert.
 
 ### transpose
 
-`Option.transpose()` vertauscht die Schachtelung eines `Option` **eines** `Result`
-in ein `Result` **eines** `Option`:
+Die beiden `transpose`-Methoden bilden ein **inverses Paar** — sie tauschen die
+Schachtelungs-Ebenen in entgegengesetzter Richtung und heben sich gegenseitig auf.
+
+**`Option.transpose()`** — `Option[Result[T, E]]` → `Result[Option[T], E]`:
 
 - `Null()` → `Ok(Null())`
 - `Some(Ok(v))` → `Ok(Some(v))` (ist `v` `None`, wirft `Some(v)` → `ValueError`)
 - `Some(Err(e))` → `Err(e)`
 - nicht-`Result`-Inhalt → `Ok(self)` (unverändert eingepackt)
+
+**`Result.transpose()`** — `Result[Option[T], E]` → `Option[Result[T, E]]`:
+
+- `Ok(Some(v))` → `Some(Ok(v))`
+- `Ok(Null())` → `Null()`
+- `Err(e)` → `Some(Err(e))`
+- `Ok(Nicht-Option-Wert)` → `Some(self)` (toleranter Fallback)
+
+Die Umkehr-Eigenschaft gilt für die drei Hauptfälle:
+`Some(Ok(v)).transpose().transpose() == Some(Ok(v))`,
+`Some(Err(e)).transpose().transpose() == Some(Err(e))`,
+`Null().transpose().transpose() == Null()`.
 
 *Avoid:* an eine Matrix-Transposition denken — `transpose` wirft nie und meint
 ausschließlich das Tauschen der beiden Schachtelungs-Ebenen.

--- a/docs/decisions/issue-16-result-transpose.md
+++ b/docs/decisions/issue-16-result-transpose.md
@@ -1,0 +1,83 @@
+# Entscheidungs-Log — Issue #16 (Result: add transpose (Result[Option] -> Option[Result]))
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Result`/`Option`-Semantik (std) · 4. ponytail-Default.
+
+`Result.transpose` als Gegenstück zu `Option.transpose` in `src/results/results.py`.
+Keine Änderung an `option.py`, `__init__.py` oder `test_option.py` (disjunkte Lanes).
+
+## E1 — Semantik: Rust-Abbildung plus toleranter Fallback
+
+- **Offener Punkt:** Welche Fälle deckt `Result.transpose` ab? Rust kennt nur
+  `Ok(Some(v))`, `Ok(None)` und `Err(e)` — was passiert bei `Ok(nicht-Option-Wert)`?
+- **Entscheidung:** Die drei Rust-Fälle werden 1:1 übernommen; ein nicht-`Option`-
+  Inhalt in `Ok` löst den toleranten Fallback `Some(self)` aus — identisch mit dem
+  Fallback in `Option.transpose` (`case _: return Ok(self)`).
+- **Begründung:** (2) Konsistenz: `Option.transpose` hat denselben Fallback;
+  das Spiegeln des Verhaltens macht das Paar symmetrisch und vermeidet eine
+  `TypeError`-Ausnahme, die den Aufrufer unerwartet trifft.
+- **Verworfen:** `raise TypeError` bei unbekanntem Inhalt.
+
+## E2 — Implementierungsform: polymorphe Dispatch, kein isinstance
+
+- **Offener Punkt:** Kann die Fallunterscheidung in der Basisklasse per
+  `isinstance`-Check erfolgen?
+- **Entscheidung:** Nein. Das Architektur-Prinzip verbietet `isinstance`-Checks auf
+  der eigenen Variante. `Ok.transpose` verwendet `match self._inner_value` (Payload-
+  Matching ist erlaubt); `Err.transpose` gibt schlicht `Some(self)` zurück.
+- **Begründung:** (1) CLAUDE.md: „Behavior is selected by POLYMORPHISM only —
+  NEVER isinstance/flag/is None/truthiness checks on self's variant."
+
+## E3 — Typparameter: method-level `[U]` / `[T, U]`
+
+- **Offener Punkt:** Welche Typparameter brauchen die Signaturen?
+- **Entscheidung:**
+  - Basis-ABC: `def transpose[U](self) -> Option[Result[U, E]]`
+  - `Ok.transpose`: `def transpose[U, E](self) -> Option[Result[U, E]]` — `E` als
+    freier Parameter, da `Ok[T]` deklariert ist als `Result[T, Any]`.
+  - `Err.transpose`: `def transpose[T, U](self) -> Option[Result[U, E]]` — `T` und
+    `U` als freie Parameter, da `Err[E]` deklariert ist als `Result[Any, E]`.
+- **Begründung:** (2) Konventionstreue: dasselbe Muster nutzen `Ok.map_err` und
+  `Err.map` — freie Typparameter auf der inerten Variante, damit die Signatur mit
+  der ABC-Basis übereinstimmt.
+
+## E4 — cast für den Fallback-Zweig in `Ok.transpose`
+
+- **Offener Punkt:** `Some(self)` im `case _`-Zweig: mypy meldet
+  `Argument 1 to "Some" has incompatible type "Ok[T]"; expected "Result[U, E]"`.
+- **Entscheidung:** `Some(cast(Result[U, E], self))` — ein `cast` macht mypy klar,
+  dass `Ok[T]` hier als `Result[U, E]` behandelt wird.
+- **Begründung:** (2) Konsistenz: `Ok.map_err` nutzt ebenfalls `cast(U, …)` für
+  den analogen Typ-Mismatch. `cast` ist reines Typ-Annotation-Werkzeug ohne
+  Laufzeit-Kosten.
+- **Verworfen:** `# type: ignore` (zu grob), Umstrukturierung der Rückgabe (unnötig).
+
+## E5 — Placement: nach `or_else`, vor `unwrap`
+
+- **Offener Punkt:** Wo in der Methodenliste wird `transpose` eingefügt?
+- **Entscheidung:** Unmittelbar nach `or_else` (alphabetisch: `t` > `o`), vor
+  `unwrap` — gilt für ABC, `Ok` und `Err` gleichermaßen.
+- **Begründung:** (2) Konsistenz mit dem bestehenden Ordnungsprinzip.
+
+## E6 — Invariante: kein None-Check nötig
+
+- **Offener Punkt:** Muss `transpose` selbst prüfen, ob der extrahierte Wert `None`
+  ist?
+- **Entscheidung:** Nein. `transpose` gibt immer einen `Result` oder `Null()` zurück,
+  nie einen rohen Wert in `Some`. `Some.__init__` fängt `None` bereits ab, falls es
+  unerwartet auftritt.
+- **Begründung:** (1) Invariante: „The invariant is enforced EXACTLY ONCE at the
+  construction boundary." Eigene None-Checks wären defensive Duplikation.
+
+## E7 — Doku-Synchronisation
+
+- **Offener Punkt:** Welche Doku-Dateien berührt diese Änderung?
+- **Entscheidung:** (a) Der bestehende `### transpose`-Abschnitt in `CONTEXT.md`
+  (Zeile ~287) wird erweitert, um **beide** Richtungen zu dokumentieren.
+  (b) Dieses Entscheidungs-Log unter `docs/decisions/issue-16-result-transpose.md`.
+  (c) `CLAUDE.md` wird **nicht** geändert.
+- **Begründung:** (1) CLAUDE.md-Anweisung: CONTEXT.md ist das maßgebliche Glossar;
+  der bestehende Abschnitt beschreibt bereits `Option.transpose` — er wird erweitert,
+  nicht dupliziert.

--- a/src/results/results.py
+++ b/src/results/results.py
@@ -154,6 +154,19 @@ class Result[T, E](abc.ABC):
         """Returns the result if it is [`Ok`], otherwise calls `op` with the wrapped error and returns the result."""
 
     @abc.abstractmethod
+    def transpose[U](self) -> Option[Result[U, E]]:
+        """Transposes a `Result` of an `Option` into an `Option` of a `Result`.
+
+        - `Ok(Some(v))` → `Some(Ok(v))`
+        - `Ok(Null())` → `Null()`
+        - `Err(e)` → `Some(Err(e))`
+        - `Ok(non-Option value)` → `Some(self)` (lenient fallback)
+
+        This is the mirror image of [`Option.transpose`], and the two are inverses:
+        `Some(Ok(v)).transpose().transpose() == Some(Ok(v))`.
+        """
+
+    @abc.abstractmethod
     def unwrap(self) -> T:
         """Returns the contained [`Ok`] value, consuming the `self` value.
         Raises an `UnwrapFailedError` if the value is an [`Err`].
@@ -255,6 +268,17 @@ class Ok[T](Result[T, Any]):
     def or_else[E](self, op: Callable[[E], Result[T, E]]) -> Result[T, E]:
         return Ok(self._inner_value)
 
+    def transpose[U, E](self) -> Option[Result[U, E]]:
+        match self._inner_value:
+            case Some(value):
+                return Some(Ok(value))
+            case Null():
+                return Null()
+            case _:
+                return Some(
+                    cast(Result[U, E], self)
+                )  # ponytail: lenient fallback — non-Option payload
+
     def unwrap(self) -> T:
         return self._inner_value
 
@@ -349,6 +373,9 @@ class Err[E](Result[Any, E]):
 
     def or_else[T](self, op: Callable[[E], Result[T, E]]) -> Result[T, E]:
         return op(self._inner_value)
+
+    def transpose[T, U](self) -> Option[Result[U, E]]:
+        return Some(self)
 
     def unwrap(self) -> NoReturn:
         exc = UnwrapFailedError(

--- a/tests/results/test_result.py
+++ b/tests/results/test_result.py
@@ -568,3 +568,37 @@ def test_and_or_identity() -> None:
     e = Err("e")
     assert ok.or_(Err("other")) is ok
     assert e.and_(Ok(99)) is e
+
+
+@pytest.mark.parametrize(
+    "result, expected",
+    [
+        (Ok(Some(42)), Some(Ok(42))),
+        (Ok(Null()), Null()),
+        (Err("e"), Some(Err("e"))),
+        (Ok(99), Some(Ok(99))),
+    ],
+    ids=[
+        "transpose Ok(Some(v)) -> Some(Ok(v))",
+        "transpose Ok(Null()) -> Null()",
+        "transpose Err(e) -> Some(Err(e))",
+        "transpose Ok(non-option fallback) -> Some(self)",
+    ],
+)
+def test_transpose(result, expected):
+    assert result.transpose() == expected
+
+
+def test_transpose_round_trip() -> None:
+    """transpose is the inverse of Option.transpose for the core cases."""
+    # Some(Ok(v)).transpose().transpose() == Some(Ok(v))
+    some_ok: Some[Result[int, str]] = Some(Ok(1))
+    assert some_ok.transpose().transpose() == some_ok
+
+    # Some(Err(e)).transpose().transpose() == Some(Err(e))
+    some_err: Some[Result[int, str]] = Some(Err("boom"))
+    assert some_err.transpose().transpose() == some_err
+
+    # Null().transpose().transpose() == Null()
+    null: Null[Result[int, str]] = Null()
+    assert null.transpose().transpose() == null


### PR DESCRIPTION
## Summary

- Adds `Result.transpose` (`Result[Option[T], E]` → `Option[Result[T, E]]`) as the mirror image of the existing `Option.transpose`, following Rust semantics (#16)
- Three Rust cases covered (`Ok(Some(v))` → `Some(Ok(v))`, `Ok(Null())` → `Null()`, `Err(e)` → `Some(Err(e))`) plus a lenient fallback for non-Option payloads (`Ok(x)` → `Some(self)`)
- Dispatch is purely polymorphic: `Ok.transpose` uses `match self._inner_value` (payload pattern matching); `Err.transpose` is a single-line `return Some(self)`
- Extends the `### transpose` section in `CONTEXT.md` to document both directions as inverses; adds `docs/decisions/issue-16-result-transpose.md`

Closes #16

## Test plan

- [ ] RED run confirmed: 5 failures (`AttributeError: 'Ok'/'Err' object has no attribute 'transpose'`) before implementation
- [ ] 4 parametrized cases: `Ok(Some(v))`, `Ok(Null())`, `Err(e)`, `Ok(non-option fallback)`
- [ ] Round-trip property test: `Some(Ok(v)).transpose().transpose() == Some(Ok(v))` etc.
- [ ] `uv run pytest` — 202 passed
- [ ] `uv run mypy src tests` — no issues found
- [ ] `uv run ruff check` / `ruff format` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)