### PR TITLE
feat(option): add zip / unzip (#19)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,7 +30,7 @@ Bewusst **nicht** Teil dieses Scopes:
   nicht geworfen, sondern ein `Err`/`Null` weitergereicht.
 - **Kein vollständiger Port der Rust-API.** Es existiert nur eine bewusst kleine
   Methodenauswahl. Insbesondere gibt es **kein** `unwrap_or_default` und **kein**
-  `flatten`/`zip`.
+  `flatten`.
 - **Keine Go-artigen `(value, error)`-Tupel.** Ein Ergebnis ist immer ein einzelnes
   Objekt eines der beiden Typ-Familien, nie ein Paar.
 
@@ -164,6 +164,43 @@ im `map_or` des Arguments, nicht in einem Flag-Check auf `self`.
 *Avoid:* `and_` mit `and_then` verwechseln. `and_` nimmt eine fertige Option entgegen
 (eager); `and_then` nimmt eine Funktion `T -> Option[U]` (lazy, hat Zugriff auf den
 `Some`-Wert). Beide geben `Null()` zurück, wenn `self` `Null` ist.
+
+### zip / unzip
+
+Zwei `Option`-Methoden für das **Zusammenführen und Aufteilen** von Paaren:
+
+- `zip(other: Option[U]) -> Option[tuple[T, U]]` — kombiniert zwei Options zu einer
+  Option eines Tupels. Wahrheitstabelle:
+  `Some(a).zip(Some(b)) = Some((a, b))`,
+  `Some(a).zip(Null()) = Null()`,
+  `Null().zip(Some(b)) = Null()`,
+  `Null().zip(Null()) = Null()`.
+  Mit anderen Worten: `Some((a, b))` entsteht **nur**, wenn beide Seiten `Some` sind;
+  eine einzige `Null`-Seite ergibt `Null()`.
+
+- `unzip[A, B](self: Option[tuple[A, B]]) -> tuple[Option[A], Option[B]]` — teilt eine
+  Option eines Tupels in ein Paar von Options auf.
+  `Some((a, b)).unzip() = (Some(a), Some(b))`,
+  `Null().unzip() = (Null(), Null())`.
+
+Beide Methoden sind polymorphisch implementiert (`@abc.abstractmethod` auf `Option`,
+je eine Implementierung auf `Some` und `Null`); kein `isinstance`-, `is None`- oder
+Truthiness-Check im Körper. `Some.zip`'s Abhängigkeit von der Variante des Arguments
+wird via `other.map(lambda b: (self._value, b))` aufgelöst — `map` auf `Some` erzeugt
+`Some((a, b))`, `map` auf `Null` gibt `Null()` zurück; kein Flag-Check auf `self`.
+
+**Invarianten-Interaktion mit `Some(None)`:** `unzip` destrukturiert das Tupel und
+baut jede Komponente mit `Some(...)` auf. Enthält das Tupel `None` als Komponente
+(z. B. `Some((None, 5))` oder `Some((5, None))`), wirft `Some(None)` beim Konstruieren
+`ValueError("Some(None) is forbidden; use Null() for absence")`. Der Guard liegt
+**ausschließlich** in `Some.__init__` — `unzip` selbst fügt keinen `None`-Check hinzu.
+`Some((None, 5))` ist konstruierbar (das Tupel selbst ist nicht `None`); erst
+`unzip()` löst den Guard aus.
+
+*Avoid:* `zip` mit `and_` verwechseln. `and_` gibt die zweite Option unverändert
+zurück; `zip` kombiniert beide Werte in einem neuen `Some((a, b))`. `unzip` ist
+kein Gegenstück zu `and_then` — es operiert ausschließlich auf `Option[tuple[A, B]]`
+und gibt stets ein Paar von Options zurück.
 
 ### unwrap
 

--- a/docs/decisions/issue-19-option-zip-unzip.md
+++ b/docs/decisions/issue-19-option-zip-unzip.md
@@ -1,0 +1,85 @@
+# Entscheidungs-Log — Issue #19 (Option: `zip` / `unzip`)
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Option`-Semantik (std) · 4. ponytail-Default.
+
+Lane O: ausschließlich `src/results/option.py`, zugehöriger Testmodul und CONTEXT.md
+(Anker `### and_ / xor`). Kein `results.py`-Diff.
+
+## E1 — `zip`: Dispatch via `other.map` statt Flag-Check
+
+- **Offener Punkt:** `zip` muss auf beide Varianten von `other` reagieren (`Some` → Tupel
+  wrappen, `Null` → `Null()` zurückgeben). Wie ohne `isinstance`-Check?
+- **Entscheidung:** `Some.zip(other)` → `other.map(lambda b: (self._value, b))`.
+  `map` auf `Some(b)` ergibt `Some((a, b))`; `map` auf `Null()` ergibt `Null()`.
+  Kein Flag-Check, kein `isinstance`, kein `is None`.
+- **Begründung:** (1) Dispatch-Invariante: welche Variante vorliegt, entscheidet die
+  Polymorphie — hier die von `other`. Exakt dasselbe Muster wie `xor` via `map_or`.
+  (4) ponytail: eine Zeile. Kommentiert mit `# ponytail:` im Code.
+- **Verworfen:** `if other.is_some(): return Some((self._value, other.unwrap()))
+  else: return Null()` (Truthiness-äquivalent, bricht die Dispatch-Invariante).
+
+## E2 — `zip` auf `Null`: gibt direkt `Null()` zurück
+
+- **Entscheidung:** `Null.zip(other)` → `return Null()`. Kein Blick auf `other`'s
+  Variante nötig — ein `Null` auf der linken Seite ergibt immer `Null()`.
+- **Begründung:** (3) Rust-Semantik: `Null.zip` ist immer `Null()`, unabhängig von
+  `other`. (4) ponytail: eine Zeile, kein Branching.
+
+## E3 — `unzip`: Typ-Annotation mit Self-Type-Generic
+
+- **Offener Punkt:** `unzip` operiert nur sinnvoll auf `Option[tuple[A, B]]`. Wie
+  annotiert man `self` korrekt ohne `isinstance`-Check und ohne TypeVar?
+- **Entscheidung:** PEP 695 Self-Type-Generic auf der Implementierung:
+  `def unzip[A, B](self: Some[tuple[A, B]]) -> tuple[Option[A], Option[B]]`.
+  Auf der ABC: `def unzip[A, B](self: Option[tuple[A, B]]) -> tuple[Option[A], Option[B]]`.
+- **Begründung:** (2) Projekt-Konvention — PEP 695 Generics durchgängig.
+  (1) mypy akzeptiert Self-Type-Narrowing in `@abc.abstractmethod`-Stubs.
+  Kein `TypeVar`, keine `Generic`-Umstellung nötig.
+- **Verworfen:** `def unzip(self) -> tuple[Option[Any], Option[Any]]` (zu schwach
+  für statische Analyse).
+
+## E4 — `unzip`: Invarianten-Interaktion `Some(None)` — kein manueller None-Check
+
+- **Offener Punkt:** Was passiert, wenn eine Tupelkomponente `None` ist, z. B.
+  `Some((None, 5)).unzip()`? Braucht `unzip` einen eigenen `None`-Check?
+- **Entscheidung:** **Kein** manueller `None`-Check in `unzip`. `Some.unzip` destrukturiert
+  `a, b = self._value` und ruft `Some(a)` bzw. `Some(b)` auf. Ist eine Komponente
+  `None`, wirft `Some.__init__` bereits `ValueError("Some(None) is forbidden; …")`.
+  Der Guard in `Some.__init__` ist der **einzige** Enforcement-Punkt — `unzip`
+  verlässt sich darauf.
+- **Begründung:** (1) CLAUDE.md-Invariante: „Enforced EXACTLY ONCE at the construction
+  boundary: `Some.__init__`." Jeder zusätzliche Check wäre Duplikation.
+  (4) ponytail: weniger Code, gleiche Korrektheit. Explizit mit zwei Parametrized-Tests
+  abgesichert: `Some((None, 5)).unzip()` und `Some((5, None)).unzip()` werfen beide
+  `ValueError`.
+- **Verworfen:** `if a is None or b is None: raise ValueError(...)` in `unzip` (verletzt
+  das Single-Enforcement-Prinzip).
+
+## E5 — Methodenplatzierung: alphabetisch nach `xor`
+
+- **Entscheidung:** `zip` und `unzip` werden **nach** `xor` eingefügt — alphabetisch
+  kommen `u` (unzip) und `z` (zip) nach `x` (xor). Reihenfolge im Körper: `unzip`
+  vor `zip` (u < z). Identisch in `Option`-ABC, `Some` und `Null`.
+- **Begründung:** (2) Bestehende Konvention — alle Methoden sind alphabetisch
+  geordnet (siehe Issue #17, #18).
+
+## E6 — CONTEXT.md: Abschnitt `### zip / unzip` + Korrektur im Scope-Abschnitt
+
+- **Offener Punkt:** Wo genau in CONTEXT.md?
+- **Entscheidung:** Unmittelbar nach `### and_ / xor`, vor `### unwrap`.
+  Zusätzlich: der „Nicht-Teil-des-Scopes"-Abschnitt erwähnte `flatten`/`zip` als
+  bewusst fehlend — `zip` ist jetzt vorhanden, daher wurde `zip` aus dieser Liste
+  entfernt (nur `flatten` verbleibt).
+- **Begründung:** (1) Aufgabenstellung: Anker `### and_ / xor`. (2) Konsistenz —
+  das Glossar muss den Code widerspiegeln.
+
+## E7 — TDD: Failing Tests vor der Implementierung
+
+- **Vorgehen:** Acht neue Testfälle (vier für `zip`, zwei für `unzip` happy path,
+  zwei für `unzip` None-Komponente raises) als parametrized-Einträge in
+  `tests/results/test_option.py` eingefügt, **bevor** die Implementierung in
+  `option.py` erfolgte. Acht rote Fehler bestätigt (`AttributeError: 'Some' object
+  has no attribute 'zip'`), dann alle 205 Tests grün.

--- a/src/results/option.py
+++ b/src/results/option.py
@@ -350,6 +350,44 @@ class Option[T](abc.ABC):
         >>> assert Null().xor(Null()) == Null()
         """
 
+    @abc.abstractmethod
+    def zip[U](self, other: Option[U]) -> Option[tuple[T, U]]:
+        """Zips `self` with another `Option`.
+
+        If `self` is `Some(a)` and `other` is `Some(b)`, returns `Some((a, b))`.
+        Otherwise returns `Null()`.
+
+        Truth table::
+
+            Some(a).zip(Some(b))   == Some((a, b))
+            Some(a).zip(Null())    == Null()
+            Null().zip(Some(b))    == Null()
+            Null().zip(Null())     == Null()
+
+        # Examples:
+
+        >>> assert Some(1).zip(Some("x")) == Some((1, "x"))
+        >>> assert Some(1).zip(Null()) == Null()
+        >>> assert Null().zip(Some("x")) == Null()
+        >>> assert Null().zip(Null()) == Null()
+        """
+
+    @abc.abstractmethod
+    def unzip[A, B](self: Option[tuple[A, B]]) -> tuple[Option[A], Option[B]]:
+        """Unzips an option containing a tuple of two values.
+
+        If `self` is `Some((a, b))`, returns `(Some(a), Some(b))`.
+        If `self` is `Null()`, returns `(Null(), Null())`.
+
+        Invariante: Ist eine Tupelkomponente `None`, wirft `Some(None)` beim
+        Konstruieren `ValueError` — der Guard in `Some.__init__` greift auch hier.
+
+        # Examples:
+
+        >>> assert Some((1, "x")).unzip() == (Some(1), Some("x"))
+        >>> assert Null().unzip() == (Null(), Null())
+        """
+
 
 @final
 class Some[T](Option[T]):
@@ -462,6 +500,15 @@ class Some[T](Option[T]):
         # `default` (self) when optb is Null and `op(v)` (Null()) when optb is Some.
         return optb.map_or(self, lambda _: Null())
 
+    def zip[U](self, other: Option[U]) -> Option[tuple[T, U]]:
+        # ponytail: whether `other` is Some or Null is resolved through other.map —
+        # no flag check or isinstance on self's variant; the dispatch lives in `other`.
+        return other.map(lambda b: (self._value, b))
+
+    def unzip[A, B](self: Some[tuple[A, B]]) -> tuple[Option[A], Option[B]]:
+        a, b = self._value
+        return (Some(a), Some(b))
+
 
 @final
 class Null[T](Option[T]):
@@ -560,3 +607,9 @@ class Null[T](Option[T]):
 
     def xor(self, optb: Option[T]) -> Option[T]:
         return optb
+
+    def zip[U](self, other: Option[U]) -> Option[tuple[T, U]]:
+        return Null()
+
+    def unzip[A, B](self: Null[tuple[A, B]]) -> tuple[Option[A], Option[B]]:
+        return (Null(), Null())

--- a/tests/results/test_option.py
+++ b/tests/results/test_option.py
@@ -632,3 +632,57 @@ def test_dead_option_error_hierarchy_is_no_longer_exported(removed_name):
 
     assert not hasattr(results, removed_name)
     assert removed_name not in results.__all__
+
+
+@pytest.mark.parametrize(
+    "option_a, option_b, expected",
+    [
+        (Some(1), Some("x"), Some((1, "x"))),
+        (Some(1), Null(), Null()),
+        (Null(), Some("x"), Null()),
+        (Null(), Null(), Null()),
+    ],
+    ids=[
+        "test_zip_when_both_some_should_return_some_tuple",
+        "test_zip_when_some_and_null_should_return_null",
+        "test_zip_when_null_and_some_should_return_null",
+        "test_zip_when_both_null_should_return_null",
+    ],
+)
+def test_zip_when_called_should_return_some_tuple_or_null(
+    option_a: Option, option_b: Option, expected: Option
+) -> None:
+    assert option_a.zip(option_b) == expected
+
+
+@pytest.mark.parametrize(
+    "option, expected",
+    [
+        (Some((1, "x")), (Some(1), Some("x"))),
+        (Null(), (Null(), Null())),
+    ],
+    ids=[
+        "test_unzip_when_some_tuple_should_return_pair_of_somes",
+        "test_unzip_when_null_should_return_pair_of_nulls",
+    ],
+)
+def test_unzip_when_called_should_split_option_tuple_into_pair(
+    option: Option, expected: tuple
+) -> None:
+    assert option.unzip() == expected
+
+
+@pytest.mark.parametrize(
+    "option",
+    [
+        Some((None, 5)),
+        Some((5, None)),
+    ],
+    ids=[
+        "test_unzip_when_first_component_is_none_should_raise_value_error",
+        "test_unzip_when_second_component_is_none_should_raise_value_error",
+    ],
+)
+def test_unzip_when_component_is_none_should_raise_value_error(option: Option) -> None:
+    with pytest.raises(ValueError, match="Some.None. is forbidden"):
+        option.unzip()


### PR DESCRIPTION
## Summary

- Implements `Option.zip(other)`: zips two Options into an `Option[tuple[T, U]]`. Returns `Some((a, b))` when both sides are `Some`; `Null()` if either side is `Null`. Dispatch through `other.map` — no `isinstance`/flag check, purely polymorphic.
- Implements `Option.unzip()`: splits an `Option[tuple[A, B]]` into `(Option[A], Option[B])`. On `Some((a, b))` returns `(Some(a), Some(b))`; on `Null()` returns `(Null(), Null())`. None-component guard fires through `Some.__init__` (single enforcement point — no per-method check added).
- 8 new parametrized tests: all 4 `zip` variant combos, `unzip` happy path, `unzip` on `Null`, and both `Some((None, x)).unzip()` / `Some((x, None)).unzip()` raise-on-None cases.
- CONTEXT.md: new `### zip / unzip` section inserted immediately after `### and_ / xor`; `zip` removed from the "not in scope" list (it now exists).
- `docs/decisions/issue-19-option-zip-unzip.md`: German decision log matching project style.

Closes #19.

## Test plan

- [x] `uv run pytest` — 205 passed (was 197 before this PR)
- [x] `uv run mypy src tests` — no issues found
- [x] `uv run ruff check` — all checks passed
- [x] `uv run ruff format --check` — all files already formatted
- [x] Red-first TDD confirmed: 8 failures on `AttributeError: 'Some' object has no attribute 'zip'` before implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)