### PR TITLE
feat(option): add flatten — collapse one level of Option nesting

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,8 +29,7 @@ Bewusst **nicht** Teil dieses Scopes:
   den Rändern eingefangen (siehe `as_result`/`from_fn`); innerhalb der Kette wird
   nicht geworfen, sondern ein `Err`/`Null` weitergereicht.
 - **Kein vollständiger Port der Rust-API.** Es existiert nur eine bewusst kleine
-  Methodenauswahl. Insbesondere gibt es **kein** `unwrap_or_default` und **kein**
-  `flatten`.
+  Methodenauswahl. Insbesondere gibt es **kein** `unwrap_or_default`.
 - **Keine Go-artigen `(value, error)`-Tupel.** Ein Ergebnis ist immer ein einzelnes
   Objekt eines der beiden Typ-Familien, nie ein Paar.
 
@@ -302,6 +301,37 @@ Verkettet eine Folgeoperation, die selbst wieder ein `Result`/`Option` liefert
 
 *Avoid:* `and_then` als „map" beschreiben. Der Unterschied ist genau die
 Verpackungs-Ebene des Rückgabewerts.
+
+### flatten
+
+Kollabiert **eine** Verschachtelungsebene eines `Option[Option[T]]` zu `Option[T]`.
+
+Abbildungsregeln:
+
+- `Some(Some(x))` → `Some(x)`
+- `Some(Null())`  → `Null()`
+- `Null()`        → `Null()`
+
+`flatten` ist die benannte Form von `and_then(lambda x: x)` (Identity-Flatmap):
+statt einen Wert zu transformieren, gibt es das innere `Option` direkt durch.
+
+**`Some.flatten` ist eine Identitätsoperation:** Die Implementierung gibt
+`self._value` direkt zurück — kein neuer Container entsteht, kein Wert wird
+neu eingepackt. Folge: `Some(inner).flatten() is inner` (Objektidentität).
+Da nichts eingepackt wird, entsteht kein neues `Some` und damit kein
+`Some(None)`-Risiko; der Guard in `Some.__init__` wird gar nicht erreicht.
+
+`Null.flatten` gibt ein frisches `Null()` zurück.
+
+Beide Implementierungen sind polymorphisch (`@abc.abstractmethod` auf `Option`,
+je eine Implementierung auf `Some` und `Null`); kein `isinstance`-, `is None`-
+oder Truthiness-Check im Körper.
+
+*Avoid:* `flatten` mit `map` oder `and_then` verwechseln. `map(f)` transformiert
+den Inhalt und verpackt ihn neu; `and_then(f)` wendet eine Funktion an, die
+selbst ein `Option` zurückgibt. `flatten` nimmt keine Funktion — es setzt nur
+voraus, dass der Inhalt bereits ein `Option` ist (`Option[Option[T]]`), und
+entfernt die äußere Hülle.
 
 ### Cross-Conversion
 

--- a/docs/decisions/issue-20-option-flatten.md
+++ b/docs/decisions/issue-20-option-flatten.md
@@ -1,0 +1,93 @@
+# Entscheidungs-Log — Issue #20 (Option: `flatten`)
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Option`-Semantik (std) · 4. ponytail-Default.
+
+Lane O: ausschließlich `src/results/option.py`, zugehöriger Testmodul und CONTEXT.md.
+Kein `results.py`-Diff.
+
+## E1 — `Some.flatten` gibt `self._value` direkt zurück (Identität, kein Re-Wrap)
+
+- **Offener Punkt:** Soll `Some.flatten` den Inhalt neu in `Some(...)` einpacken
+  oder direkt durchreichen?
+- **Entscheidung:** `return self._value` — kein neues `Some`, kein neues `Null`.
+  `self._value` ist bereits ein `Option[U]`, also das korrekte Ergebnis für alle
+  drei Fälle:
+  - `Some(Some(x))._value == Some(x)` → liefert `Some(x)`.
+  - `Some(Null())._value == Null()` → liefert `Null()`.
+- **Begründung:** (1) Aufgabenstellung: „Implement as `return self._value`". (3) Rust-
+  Semantik: `Option::flatten` ist äquivalent zu `and_then(|x| x)` — die innere Option
+  wird unverändert durchgereicht. (4) ponytail: kein neues Objekt, O(1), minimale
+  Implementierung. Die Identitätseigenschaft (`Some(inner).flatten() is inner`) folgt
+  direkt aus dem direkten Rückgabe.
+- **Verworfen:** `Some(self._value.unwrap())` o. ä. (unnötiger Zwischenschritt,
+  würde auf `Null()` als inner scheitern), `Null() if self._value.is_none() else
+  Some(self._value.unwrap())` (instanceof/flag-Check, verletzt Polymorphie-Regel).
+
+## E2 — Kein `None`-Check in `flatten`
+
+- **Offener Punkt:** Muss `flatten` prüfen, ob das Ergebnis `None` ist?
+- **Entscheidung:** Nein. `flatten` verpackt nichts neu — `self._value` war
+  bereits beim Konstruieren von `Some(inner)` durch den Guard in `Some.__init__`
+  validiert (kein `None` kommt durch). `Null()` ist kein `None`. Kein
+  zusätzlicher `if result is None: raise ValueError(...)` notwendig.
+- **Begründung:** (1) Aufgabenstellung: „Do NOT add any None handling." Das
+  `Some(None)`-Risiko entsteht nur beim Einpacken (`Some(value)`); da `flatten`
+  nichts einpackt, gibt es kein Risiko.
+- **Konsequenz:** Kein `raise`-on-None-Test in der Testsuite — es gibt nichts,
+  was `ValueError` auslösen könnte.
+
+## E3 — Kein Raise-on-None-Test
+
+- **Offener Punkt:** Soll ein Test `Some(None).flatten()` abdecken?
+- **Entscheidung:** Nein. `Some(None)` kann nicht konstruiert werden
+  (`Some.__init__` wirft sofort `ValueError`). Ein Test für
+  `Some(None).flatten()` wäre tautologisch mit dem bestehenden
+  `test_some_none_is_forbidden`-Test — er würde nicht `flatten` testen, sondern
+  nur den Konstruktor-Guard. Kein neuer Test.
+- **Begründung:** (2) Konvention: Tests decken das Verhalten der Methode ab,
+  nicht erneut das der Konstruktoren.
+
+## E4 — Selbst-Typ-Signatur mit PEP 695
+
+- **Offener Punkt:** Wie soll die Signatur des Selbst-Typ-Parameters auf dem ABC
+  und den konkreten Klassen aussehen?
+- **Entscheidung:**
+  - ABC: `def flatten[U](self: Option[Option[U]]) -> Option[U]`
+  - `Some`: `def flatten[U](self: Some[Option[U]]) -> Option[U]`
+  - `Null`: `def flatten[U](self: Null[Option[U]]) -> Option[U]`
+- **Begründung:** (2) Konvention: alle anderen Self-Typ-Methoden (`unzip`,
+  `transpose`) verwenden dieselbe PEP-695-Syntax mit `[U]` auf Methodenebene.
+  Der Self-Typ auf dem Parameter bewirkt, dass mypy `flatten` nur dann als
+  aufrufbar akzeptiert, wenn das äußere `Option` tatsächlich ein
+  `Option[Option[U]]` ist — statische Typsicherheit ohne Laufzeit-Check.
+- **Verworfen:** `TypeVar`-basierte Signaturen (wären inkonsistent mit dem
+  restlichen Codebase-Stil).
+
+## E5 — `flatten` ist äquivalent zu `and_then(identity)`
+
+- **Notiz:** `Some(inner).flatten()` gibt `inner` zurück; dasselbe erreicht
+  `Some(inner).and_then(lambda x: x)`. `flatten` ist also die benannte,
+  idiomatische Form — kein `isinstance`, kein `is None`, sondern reines Flatmap
+  mit der Identitätsfunktion. Die Eigenschaft wird in CONTEXT.md dokumentiert.
+
+## E6 — TDD: Failing Tests vor der Implementierung
+
+- **Vorgehen:** Alle vier neuen Testfälle (drei Mapping-Fälle in
+  `test_flatten_collapses_one_level_of_nesting` + ein Identitäts-Pin in
+  `test_flatten_some_returns_inner_option_identity`) wurden in
+  `tests/results/test_option.py` eingefügt, **bevor** die Implementierung in
+  `option.py` erfolgte. Vier rote Fehler (`AttributeError: 'Some'/'Null' object
+  has no attribute 'flatten'`) bestätigt, dann alle 214 Tests grün.
+
+## E7 — CONTEXT.md: neuer Abschnitt `### flatten` nach `### and_then`
+
+- **Offener Punkt:** Wo in CONTEXT.md einfügen?
+- **Entscheidung:** Unmittelbar vor `### Cross-Conversion`, nach `### and_then`.
+  `flatten` ist eng mit `and_then` verwandt (es ist `and_then(identity)`);
+  diese Nachbarschaft macht die Beziehung sichtbar. Außerdem wird
+  `flatten` aus der „bewusst nicht in Scope"-Liste im Intro entfernt.
+- **Begründung:** (2) Konvention: Methoden stehen thematisch gruppiert in
+  CONTEXT.md; `flatten` gehört in die Combinator-Gruppe.

--- a/src/results/option.py
+++ b/src/results/option.py
@@ -143,6 +143,27 @@ class Option[T](abc.ABC):
         """
 
     @abc.abstractmethod
+    def flatten[U](self: Option[Option[U]]) -> Option[U]:
+        """Collapses one level of `Option` nesting.
+
+        Mappings:
+
+        - `Some(Some(x))` → `Some(x)`
+        - `Some(Null())`  → `Null()`
+        - `Null()`        → `Null()`
+
+        This is the named form of `and_then(lambda x: x)` (identity flatmap).
+        `Some.flatten` returns the stored inner `Option` unchanged — it is an
+        identity operation (`Some(inner).flatten() is inner`), never re-wraps.
+
+        # Examples:
+
+        >>> assert Some(Some(5)).flatten() == Some(5)
+        >>> assert Some(Null()).flatten() == Null()
+        >>> assert Null().flatten() == Null()
+        """
+
+    @abc.abstractmethod
     def inspect(self, fn: Callable[[T], object]) -> Option[T]:
         """
         Calls `fn` with the contained value if [`Some`], returns `self` unchanged.
@@ -429,6 +450,11 @@ class Some[T](Option[T]):
     def filter(self, predicate: Callable[[T], bool]) -> Option[T]:
         return self if predicate(self._value) else Null()
 
+    def flatten[U](self: Some[Option[U]]) -> Option[U]:
+        # ponytail: self._value is already an Option[U] — return it directly.
+        # No re-wrap, no None risk, O(1). Identity: Some(inner).flatten() is inner.
+        return self._value
+
     def inspect(self, fn: Callable[[T], object]) -> Option[T]:
         fn(self._value)
         return self
@@ -544,6 +570,9 @@ class Null[T](Option[T]):
 
     def filter(self, predicate: Callable[[T], bool]) -> Option[T]:
         return self
+
+    def flatten[U](self: Null[Option[U]]) -> Option[U]:
+        return Null()
 
     def inspect(self, fn: Callable[[T], object]) -> Option[T]:
         return self

--- a/tests/results/test_option.py
+++ b/tests/results/test_option.py
@@ -617,6 +617,34 @@ def test_transpose_with_result(option, expected):
 
 
 @pytest.mark.parametrize(
+    "option, expected",
+    [
+        (Some(Some(5)), Some(5)),
+        (Some(Null()), Null()),
+        (Null(), Null()),
+    ],
+    ids=[
+        "some_some_to_some",
+        "some_null_to_null",
+        "null_to_null",
+    ],
+)
+def test_flatten_collapses_one_level_of_nesting(
+    option: Option, expected: Option
+) -> None:
+    assert option.flatten() == expected
+
+
+def test_flatten_some_returns_inner_option_identity() -> None:
+    # Some.flatten must return the inner Option unchanged — not a re-wrapped copy.
+    inner_some: Option[int] = Some(5)
+    assert Some(inner_some).flatten() is inner_some
+
+    inner_null: Option[int] = Null()
+    assert Some(inner_null).flatten() is inner_null
+
+
+@pytest.mark.parametrize(
     "removed_name",
     [
         "OptionError",


### PR DESCRIPTION
## Summary

Closes #20

- Adds `Option.flatten[U](self: Option[Option[U]]) -> Option[U]` with full polymorphic dispatch.
- `Some(Some(x)).flatten()` → `Some(x)`, `Some(Null()).flatten()` → `Null()`, `Null().flatten()` → `Null()`.
- `Some.flatten` returns `self._value` directly — no re-wrap, pure identity: `Some(inner).flatten() is inner` (object identity preserved).

## Design invariants maintained

**Polymorphic dispatch only:** `@abc.abstractmethod` stub on `Option`, one impl each on `Some` and `Null`. No `isinstance`, no `is None`, no truthiness check.

**Identity / no re-wrap:** `Some.flatten` is `return self._value`. Because `Some(inner)` already validated `inner is not None` at construction time, returning the stored value directly is safe and produces no `Some(None)` risk. The `Some.__init__` guard fires once at construction — `flatten` never reaches it.

**No raise-on-None test:** Nothing is re-wrapped in `flatten`, so no new `Some(None)` can arise. The existing `test_some_none_is_forbidden` test already covers the guard.

**PEP 695 generics preserved:** Method-level `[U]` with self-type on parameter — mypy validates that `flatten` is only callable on `Option[Option[U]]`.

## Quality gate

```
uv run pytest        → 214 passed
uv run mypy src tests → no issues found in 9 source files
uv run ruff check    → All checks passed!
uv run ruff format   → 9 files already formatted
```

## TDD trace

4 tests written first (RED: `AttributeError: 'Some'/'Null' object has no attribute 'flatten'`), then implementation added (GREEN: all 214 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>