### PR TITLE
docs: align prose docs with real API (README examples, CONTEXT scope)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,8 +28,10 @@ Bewusst **nicht** Teil dieses Scopes:
 - **Kein Ersatz für `try`/`except` als Sprachmittel.** Ausnahmen werden nur an
   den Rändern eingefangen (siehe `as_result`/`from_fn`); innerhalb der Kette wird
   nicht geworfen, sondern ein `Err`/`Null` weitergereicht.
-- **Kein vollständiger Port der Rust-API.** Es existiert nur eine bewusst kleine
-  Methodenauswahl. Insbesondere gibt es **kein** `unwrap_or_default`.
+- **Kein vollständiger Port der Rust-API.** Bereitgestellt wird eine kuratierte
+  Methodenauswahl, nicht die vollständige Rust-Oberfläche; insbesondere gibt es
+  **kein** `unwrap_or_default` (Python kennt keinen universellen Default-Wert je
+  Typ — wer einen Standard braucht, nimmt `unwrap_or(default)`).
 - **Keine Go-artigen `(value, error)`-Tupel.** Ein Ergebnis ist immer ein einzelnes
   Objekt eines der beiden Typ-Familien, nie ein Paar.
 
@@ -115,9 +117,7 @@ Die abwesende Variante von `Option`; `@final`-Subklasse ohne gespeicherten Wert.
 
 *Avoid:* „Pythons `None`", „Nil", „Nothing". `Null()` ist ein eigenständiger
 `Option`-Typ für Abwesenheit — nicht das `None` selbst und kein `Some`, das ein
-`None` umhüllt. Die in einigen Docstrings gezeigten Aufrufe mit Argument
-(`Null("Error")`, `Null(10)`) sind fehlerhaft: `Null` nimmt keine Parameter und
-würde mit `TypeError` scheitern.
+`None` umhüllt.
 
 ### is_none_or / inspect
 

--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@ This library provides a robust mechanism for handling operations that can result
 - **and_then**: Chains operations on `Ok` values.
 
   ```python
-  >>> assert Result.Ok(2).and_then(sq_then_to_string) == Ok("4")
-  >>> assert Result.Err("Not a number").and_then(sq_then_to_string) == Err("Not a number")
+  >>> assert Ok(2).and_then(lambda n: Ok(str(n * n))) == Ok("4")
+  >>> assert Err("Not a number").and_then(lambda n: Ok(str(n * n))) == Err("Not a number")
   ```
 
 - **as_result**: Decorator to convert function return values to `Result`.
 
   ```python
   >>> @Result.as_result
-  >>> def div(a: int, b: int) -> float:
+  ... def div(a: int, b: int) -> float:
   ...     return a / b
-  >>> assert div(10, 2) == Result.Ok(5.0)
-  >>> assert div(10, 0).map_err(str) == Result.Err("division by zero")
+  >>> assert div(10, 2) == Ok(5.0)
+  >>> assert div(10, 0).map_err(str) == Err("division by zero")
   ```
 
 - **from_fn**: Executes a function and returns a `Result`.
@@ -53,16 +53,16 @@ This library provides a robust mechanism for handling operations that can result
 
 ### Option
 
-- **Some**: Represents an optional value.
+- **Some**: Represents a present value.
 
   ```python
-  >>> assert Option.some(10) == Some(10)
+  >>> assert Some(10).unwrap() == 10
   ```
 
-- **Null**: Represents the absence of a value.
+- **Null**: Represents the absence of a value (takes no arguments).
 
   ```python
-  >>> assert Option.null("Error") == Null("Error")
+  >>> assert Null().unwrap_or(0) == 0
   ```
 
 - **from_fn, as_option**: Methods to handle optional values.

--- a/docs/decisions/docs-consistency-cleanup.md
+++ b/docs/decisions/docs-consistency-cleanup.md
@@ -1,0 +1,75 @@
+# Doku-Konsistenz-Pass — Prosa-Doku gegen den realen Code abgleichen
+
+Kein Code-Refactor, sondern ein Konsistenz-Pass: abgeleitete und Prosa-Artefakte
+mit dem Code (Source of Truth) in Einklang bringen. Ein sequenzieller Slice, ein
+PR — die wenigen Doc-Dateien überschneiden sich, Parallelisierung erzeugte nur
+Konflikte.
+
+## E1 — Stale Prämissen verifiziert, nicht „repariert"
+
+- **Offener Punkt:** Der Auftrag nannte als Startpunkte (a) uneinheitlichen
+  Decision-Log-Ort (CLAUDE.md → `docs/decisions/`, real angeblich top-level
+  `decisions/`) und (b) untrackte `prompts/`- und Decision-Dateien.
+- **Befund:** Beides bereits erledigt (Commits `256e8b2`, `f87f878`). Working
+  Tree clean; alle Logs liegen getrackt unter `docs/decisions/`, das Scratch-
+  Prompt unter `docs/prompts/`. CLAUDE.md-Verweis auf
+  `docs/decisions/issue-13-split-option-module.md` ist korrekt.
+- **Entscheidung:** Keine Aktion. Prämisse war stale; verifiziert statt blind
+  „korrigiert".
+
+## E2 — `Result.Ok` / `Result.Err` / `Option.null` existieren nicht (README)
+
+- **Offener Punkt:** README-„Classes and Methods"-Beispiele referenzierten
+  `Result.Ok(...)`, `Result.Err(...)`, `Option.null(...)`.
+- **Befund (empirisch geprüft):** `Result` hat keine `Ok`/`Err`-Attribute,
+  `Option` kein `null`. Kanonische Konstruktoren sind `Ok`/`Err`/`Some`/`Null`
+  (top-level, in `__all__`). `Result.as_result`/`from_fn` und `Option.some`
+  existieren.
+- **Entscheidung:** README-Beispiele auf die reale API angeglichen und
+  selbst-lauffähig gemacht (`Ok`/`Err` direkt, Inline-Lambda statt undefiniertem
+  `sq_then_to_string`, `>>> @decorator` + `... def`). Alle Snippets laufen grün
+  (manuell verifiziert).
+
+## E3 — `Null("Error")` / `Null(10)`: toter Verweis statt Code-Bug
+
+- **Offener Punkt:** CONTEXT.md (Z. 118–120) meldete fehlerhafte Docstrings mit
+  `Null("Error")` / `Null(10)`; Auftrag: im Code fixen (`Null` nimmt keine
+  Argumente).
+- **Befund:** In `src/` existiert kein `Null(<arg>)` (alle Aufrufe arg-los) —
+  die Docstrings wurden bereits in #7/forbid-some-none gefixt. Das einzige
+  `Null("Error")` lebte in README Z. 65 (siehe E2). `Null(10)` nirgends.
+- **Entscheidung:** Kein Code-Fix nötig. README-Beispiel ersetzt (E2). Die
+  CONTEXT.md-Meta-Notiz „in einigen Docstrings … fehlerhaft" verweist damit ins
+  Leere → entfernt. Die Kernaussage „`Null()` nimmt keine Argumente" bleibt
+  (CONTEXT.md Z. 110).
+
+## E4 — `unwrap_or_default`: bewusst nicht vorhanden
+
+- **Offener Punkt:** CONTEXT.md-Scope (Z. 31–34, „bewusst kleine
+  Methodenauswahl", „kein `unwrap_or_default`") in Spannung zur gewachsenen
+  Fläche (`and_`/`or_`/`xor`/`zip`/`unzip`/`flatten`/`inspect`/…).
+- **Befund (grep):** `unwrap_or_default` existiert nirgends im Code — die
+  Negativ-Aussage stimmt. Die Fläche ist gewachsen, aber weiter ein kuratierter
+  Rust-Subset.
+- **Entscheidung:** `unwrap_or_default` bleibt absichtlich draußen — Python hat
+  keinen universellen Default-Wert je Typ (kein `Default`-Trait); ein Standard
+  drückt sich mit `unwrap_or(default)` aus. Scope-Formulierung von „bewusst
+  kleine Methodenauswahl" auf „kuratierte Methodenauswahl, nicht die vollständige
+  Rust-Oberfläche" justiert + Begründung inline ergänzt.
+
+## E5 — Historische Artefakte nicht umschreiben
+
+- **Entscheidung:** `docs/decisions/*` und `docs/prompts/seal-result-option.md`
+  dokumentieren bewusst Entferntes (`OptionError`/`TransposeError`, alte
+  `_content`-Variante, stale `Result.Ok`-Doctests). Das ist Historie, kein toter
+  Verweis im Live-Code → unangetastet. Ebenso die *negativen* Invarianten in
+  CONTEXT.md/CLAUDE.md („nie per `_content is None`") — die beschreiben korrekt,
+  was der Code **nicht** tut.
+
+## Abschluss
+
+- Berührt: `README.md`, `CONTEXT.md`, dieser Log. Kein `.py` angefasst →
+  Verhalten unverändert; `CLAUDE.md` nicht angefasst.
+- Verifikation: korrigierte README-Snippets laufen real; Dead-Ref-Sweep über
+  Prosa-Doku (Klassen/Methoden/Pfade/Log-Links) sauber; `graphify update .` als
+  letzter Schritt.


### PR DESCRIPTION
## Was

Konsistenz-Pass: Prosa-Doku gegen den realen Code (Source of Truth) abgleichen. **Kein Code geändert — Verhalten unverändert.** Ein sequenzieller Slice, ein PR.

## Befunde & Änderungen

- **README „Classes and Methods" referenzierte nicht-existente API.** `Result.Ok`/`Result.Err`/`Option.null` gibt es nicht — kanonisch sind die Top-Level `Ok`/`Err`/`Some`/`Null`. Beispiele auf reale API angeglichen und selbst-lauffähig gemacht (Inline-Lambda statt undefiniertem `sq_then_to_string`, `>>> @decorator` + `... def`). Alle Snippets laufen grün (manuell verifiziert).
- **`Null("Error")` wirft** (Null nimmt keine Argumente) → README-Beispiel ersetzt durch `Null().unwrap_or(0)`.
- **CONTEXT.md:** tote Meta-Notiz über fehlerhafte `Null("Error")`/`Null(10)`-Docstrings entfernt (in `src/` existiert kein solcher Docstring mehr; das einzige Vorkommen lebte im README und ist hier gefixt). Scope-Aussage justiert + dokumentiert, warum `unwrap_or_default` bewusst fehlt (Python hat keinen universellen Default je Typ → `unwrap_or(default)`).
- **Decision-Log** am kanonischen Ort `docs/decisions/docs-consistency-cleanup.md`.

## Stale Prämissen (verifiziert, keine Aktion)

- Decision-Log-Ort bereits unter `docs/decisions/` vereinheitlicht, Working Tree war bereits clean (Commits `256e8b2`/`f87f878`). CLAUDE.md-Verweis korrekt.
- `docs/decisions/*` und `docs/prompts/*` behalten bewusst historische Namen (`OptionError`/`TransposeError`, alte `_content`-Variante) — Historie, kein toter Live-Verweis.

## Verifikation

- Korrigierte README-Snippets laufen real gegen die Public API.
- Dead-Ref-Sweep über Live-Prosa-Doku (README/CONTEXT/CLAUDE) sauber.
- `uv run pytest`: **214 passed** (kein Code berührt → keine Regression).
- `graphify update .` als letzter Schritt, spiegelt Endzustand (graphify-out ist gitignored).
- `CLAUDE.md` unangetastet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)