### PR TITLE
refactor!: harden transpose + align Result.map_or arg order

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ __Cross-conversions__ tie the two families together: `Result.ok()` / `Result.err
 
 __Constructors from callables__: `Result.as_result` (decorator) and `Result.from_fn` wrap exception-raising functions (catching `Exception` into `Err`); `Option.as_option` (decorator) and `Option.from_fn` wrap `None`-returning functions into `Some`/`Null`.
 
-__Failure mode__: unwrap-style failures raise `UnwrapFailedError` (subclass of `ResultError`) — including `Option.expect`/`Option.unwrap`, which use this Result-side class. `Err.unwrap()` chains the original exception via `raise ... from` when the inner value is a `BaseException`.
+__Failure mode__: unwrap-style failures raise `UnwrapFailedError` (subclass of `ResultError`) — including `Option.expect`/`Option.unwrap`, which use this Result-side class. `Err.unwrap()` chains the original exception via `raise ... from` when the inner value is a `BaseException`. `Option.transpose`/`Result.transpose` raise `TransposeError` (also a `ResultError` subclass) when the payload is not the expected `Result`/`Option` wrapper — a contract violation, never silently wrapped.
 
 __Pattern matching__ relies on `__match_args__`: match `Ok`/`Err` on their inner value (`case Ok(v)`), and match the `Option` variants directly (`case Some(v)` binds the value; `case Null()` matches the empty variant).
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -361,22 +361,24 @@ Schachtelungs-Ebenen in entgegengesetzter Richtung und heben sich gegenseitig au
 - `Null()` → `Ok(Null())`
 - `Some(Ok(v))` → `Ok(Some(v))` (ist `v` `None`, wirft `Some(v)` → `ValueError`)
 - `Some(Err(e))` → `Err(e)`
-- nicht-`Result`-Inhalt → `Ok(self)` (unverändert eingepackt)
+- `Some(Nicht-Result-Wert)` → wirft `TransposeError` (kein stilles Einpacken)
 
 **`Result.transpose()`** — `Result[Option[T], E]` → `Option[Result[T, E]]`:
 
 - `Ok(Some(v))` → `Some(Ok(v))`
 - `Ok(Null())` → `Null()`
 - `Err(e)` → `Some(Err(e))`
-- `Ok(Nicht-Option-Wert)` → `Some(self)` (toleranter Fallback)
+- `Ok(Nicht-Option-Wert)` → wirft `TransposeError` (kein toleranter Fallback)
 
 Die Umkehr-Eigenschaft gilt für die drei Hauptfälle:
 `Some(Ok(v)).transpose().transpose() == Some(Ok(v))`,
 `Some(Err(e)).transpose().transpose() == Some(Err(e))`,
 `Null().transpose().transpose() == Null()`.
 
-*Avoid:* an eine Matrix-Transposition denken — `transpose` wirft nie und meint
-ausschließlich das Tauschen der beiden Schachtelungs-Ebenen.
+*Avoid:* an eine Matrix-Transposition denken — `transpose` meint ausschließlich
+das Tauschen der beiden Schachtelungs-Ebenen. Es wirft nur `TransposeError`, wenn
+der Inhalt nicht die erwartete `Result`/`Option`-Hülle ist (Programmierfehler);
+die regulären Fälle werfen nie.
 
 ### as_result / from_fn
 
@@ -413,13 +415,26 @@ Wert); `ResultError` ist eine **geworfene Ausnahme**.
 
 ### UnwrapFailedError
 
-`ResultError`-Subklasse und die einzige *bibliothekseigene* geworfene Ausnahme:
-ausgelöst von fehlgeschlagenem `unwrap`/`expect`/`unwrap_err`/`expect_err` — sowohl
-auf `Result` als auch auf `Option`. (Daneben wirft allein die verbotene
-Konstruktion `Some(None)` das eingebaute `ValueError`.)
+`ResultError`-Subklasse: ausgelöst von fehlgeschlagenem
+`unwrap`/`expect`/`unwrap_err`/`expect_err` — sowohl auf `Result` als auch auf
+`Option`. (Daneben gibt es `TransposeError` als zweite bibliothekseigene Ausnahme;
+und die verbotene Konstruktion `Some(None)` wirft das eingebaute `ValueError`.)
 
 - Invariante: Auch `Option.unwrap` wirft diese **Result-seitige** Klasse; es gibt
   keine eigene Option-seitige Fehlerklasse.
+
+### TransposeError
+
+`ResultError`-Subklasse. `Option.transpose` erwartet `Option[Result[...]]`,
+`Result.transpose` erwartet `Result[Option[...]]`. Python erzwingt das nicht auf
+Typ-Ebene; ein fremder Inhalt (`Some`/`Ok` mit Nicht-`Result`/Nicht-`Option`-Wert)
+ist ein **Programmierfehler** und wird laut abgewiesen statt still eingepackt.
+
+- Invariante: Tritt nur bei Vertragsbruch auf — die regulären `transpose`-Fälle
+  (`Ok`/`Err`/`Some`/`Null`) werfen nie.
+
+*Avoid:* `TransposeError` als normalen Kontrollfluss nutzen. Für „kein Wert" sind
+`Null()`/`Err(e)` zuständig; `TransposeError` signalisiert einen Typfehler.
 
 *Avoid:* eine eigene „OptionUnwrapError" erwarten — es gibt nur diese eine.
 

--- a/docs/decisions/map-or-argument-order.md
+++ b/docs/decisions/map-or-argument-order.md
@@ -1,0 +1,23 @@
+# Entscheidungs-Log — `Result.map_or` auf Rust-Reihenfolge `(default, op)`
+
+Datum: 2026-06-21
+Auslöser: Code-Quality-Review (Inkonsistenz der Argumentreihenfolge).
+
+## E1 — `Result.map_or(op, default)` → `Result.map_or(default, op)`
+
+- **Offener Punkt:** `Result.map_or` nahm `(op, default)`, während
+  - `Option.map_or` `(default, op)` nimmt,
+  - `Result.map_or_else` `(default, op)` nimmt,
+  - Rust `map_or(self, default, f)` = `(default, op)` ist.
+
+  `Result.map_or` war damit dreifach der Ausreißer — gegen die Schwester-Familie,
+  gegen die eigene `*_else`-Variante und gegen das Rust-Vorbild.
+- **Entscheidung:** `Result.map_or` auf `(default, op)` umgestellt (Basis-ABC, `Ok`,
+  `Err`), inkl. Parameternamen `default`/`op` wie bei `Option`. **Breaking Change** für
+  positionale Aufrufer.
+- **Begründung:** Stiller Bruch jetzt (laut, mit klarer Migration) ist besser als eine
+  dauerhaft verdrehte Signatur zwischen zwei Schwester-Typen, die positional vertauscht
+  werden kann, ohne dass ein Fehler auffällt.
+- **Migration:** `result.map_or(f, default)` → `result.map_or(default, f)`.
+- **Hinweis:** `Option.map_or` war bereits korrekt und bleibt unverändert; ebenso
+  `Some.xor`s interner Aufruf `optb.map_or(self, lambda _: Null())` (Option-Seite).

--- a/docs/decisions/transpose-raises-on-foreign-payload.md
+++ b/docs/decisions/transpose-raises-on-foreign-payload.md
@@ -1,0 +1,61 @@
+# Entscheidungs-Log — `transpose` wirft `TransposeError` bei fremdem Inhalt
+
+Datum: 2026-06-21
+Auslöser: Code-Quality-Review der `transpose`-Implementierungen.
+
+## E1 — Lenient Fallback → lautes `raise`
+
+- **Offener Punkt:** `Option.transpose`/`Result.transpose` haben einen Inhalt, der
+  nicht die erwartete `Result`/`Option`-Hülle ist (z. B. `Some("foo").transpose()`),
+  bisher still in `Ok(self)`/`Some(self)` eingepackt (toleranter Fallback).
+- **Entscheidung:** Der Fallback wird durch `raise TransposeError(...)` ersetzt. Ein
+  fremder Inhalt ist ein **Programmierfehler** und wird laut abgewiesen, nicht still
+  als Erfolg eingepackt.
+- **Begründung:**
+  - Stilles Einpacken versteckt einen Typfehler — genau das „silent-fallback /
+    papering over an invariant"-Muster, das der Review markiert hat.
+  - Das Argument „weicht von Rust ab" (siehe Verworfenes unten) trägt nicht: Rust
+    kennt den Fall gar nicht, weil `transpose` dort auf `Option<Result<…>>` bzw.
+    `Result<Option<…>>` typgebunden ist. Der **lenient Fallback wich selbst von Rust
+    ab**; er war kein Rust-Verhalten, sondern eine Python-Erfindung.
+  - Python kann die Hülle nicht auf Typ-Ebene erzwingen → ein Laufzeit-Guard an der
+    Grenze ist die ehrliche Stelle, den Vertrag zu prüfen.
+- **Verworfen:** lenient Fallback behalten (Konsistenz beider `transpose`-Methoden) —
+  konsistent, aber konsistent **falsch**: beide schluckten den Typfehler.
+
+## E2 — `TransposeError` wieder eingeführt
+
+- **Offener Punkt:** Welche Ausnahme? Eingebautes `TypeError` oder eine
+  bibliothekseigene Klasse?
+- **Entscheidung:** `TransposeError(ResultError)` in `src/results/results.py`,
+  exportiert über `results.__all__`. Reiht sich in die bestehende Fehlerhierarchie
+  (`ResultError` → `UnwrapFailedError` | `TransposeError`) ein und ist gezielt
+  abfangbar.
+- **Hinweis:** Kehrt **issue #5** um, das `TransposeError`/`OptionError` als tote
+  Klassen löschte und einen Guard-Test gegen ihren Re-Export hinterließ. `OptionError`
+  bleibt gelöscht (weiterhin ungenutzt); nur `TransposeError` kehrt zurück, jetzt mit
+  echtem `raise`-Aufrufer. Der Guard-Test wurde entsprechend aufgeteilt.
+
+## E3 — Dispatch über `.map` der Gegenfamilie statt Inner-Variant-Match
+
+- **Offener Punkt:** Beide `transpose` matchten die Variante des **inneren** Summentyps
+  (`case Ok / case Err` bzw. `case Some / case Null`) — was CLAUDE.md („Dispatch per
+  Polymorphie, nicht per `isinstance`/Variant-Match in einer Methode") widerspricht.
+- **Entscheidung:** Die Ok/Err- bzw. Some/Null-Arme kollabieren zu **einem**
+  polymorphen Aufruf auf der Gegenfamilie:
+  - `Some(result).transpose()` → `result.map(Some)` (`Ok(v).map(Some)` = `Ok(Some(v))`,
+    `Err(e).map(Some)` = `Err(e)`).
+  - `Ok(option).transpose()` → `option.map(Ok)` (`Some(v).map(Ok)` = `Some(Ok(v))`,
+    `Null().map(Ok)` = `Null()`).
+- **Folge:** Nur noch **ein** `isinstance(…, Result/Option)`-Guard bleibt — die Frage
+  „ist es die Hülle überhaupt?" (für E1). Die `Some(None)`-Sperre gilt unverändert:
+  `Some(Ok(None)).transpose()` läuft über `Ok(None).map(Some)` → `Some(None)` →
+  `ValueError`. Der entfernte `cast` in `Ok.transpose`/`Ok.map_err` fällt mit weg.
+
+## Mitgeführte Doku
+
+- `CONTEXT.md`: `transpose`-Einträge (Fallback → `raise`), „`transpose` wirft nie"
+  relativiert, `UnwrapFailedError` nicht mehr „einzige" Ausnahme, neuer
+  `### TransposeError`-Eintrag.
+- Tests: Fallback-Fälle von „liefert `Some(self)`" zu „wirft `TransposeError`"
+  umgestellt; `transpose_error_is_removed_from_public_api` → `…_is_exported`.

--- a/src/results/__init__.py
+++ b/src/results/__init__.py
@@ -4,6 +4,7 @@ from .results import (
     Ok,
     Result,
     ResultError,
+    TransposeError,
     UnwrapFailedError,
 )
 
@@ -15,5 +16,6 @@ __all__ = [
     "Result",
     "ResultError",
     "Some",
+    "TransposeError",
     "UnwrapFailedError",
 ]

--- a/src/results/option.py
+++ b/src/results/option.py
@@ -27,31 +27,34 @@ class Option[T](abc.ABC):
     def from_fn[**P](
         fn: Callable[P, T], *args: P.args, **kwargs: P.kwargs
     ) -> Option[T]:
-        """Turns a function so that it returns a `Option<T>` instead of `T | None`.
+        """Call `fn(*args, **kwargs)` and wrap its result as an `Option[T]`:
+        `None` becomes `Null()`, any other value becomes `Some(value)`.
 
         Caller is responsible for ensuring that the function does not raise an exception.
         # Examples:
 
-        >>> def get(a: int, b: int) -> float:
-        ...     return a / b
+        >>> def first(xs: list[int]) -> int | None:
+        ...     return xs[0] if xs else None
         ...
-        >>> assert Result.from_fn(div, 10, 2) == Result.Ok(5.0)
-        >>> assert Result.from_fn(div, 10, 0).map_err(str) == Result.Err("division by zero")
+        >>> assert Option.from_fn(first, [1, 2]) == Some(1)
+        >>> assert Option.from_fn(first, []) == Null()
         """
         return Null() if (result := fn(*args, **kwargs)) is None else Some(result)
 
     @staticmethod
     def as_option[**P](fn: Callable[P, T]) -> Callable[P, Option[T]]:
         """
-        Decorates a function so that it returns a `Optional<T>` instead of `T`.
+        Decorates a function so that it returns an `Option[T]` instead of `T | None`:
+        a `None` return becomes `Null()`, any other value becomes `Some(value)`.
 
         # Examples:
 
         >>> @Option.as_option
-        >>> def div(a: int, b: int) -> float:
-        ...     return a / b
-        >>> assert div(10, 2) == 5.0
-        >>> assert div(10, 0) is None
+        ... def first(xs: list[int]) -> int | None:
+        ...     return xs[0] if xs else None
+        ...
+        >>> assert first([1, 2]) == Some(1)
+        >>> assert first([]) == Null()
         """
 
         @functools.wraps(fn)
@@ -293,19 +296,22 @@ class Option[T](abc.ABC):
         """
         Transposes an `Option` of a [`Result`] into a [`Result`] of an `Option`.
 
-        Null will be mapped to:
-        #### Ok(Null)
-        Some(Ok(_)) and Some(Err(_)) will be mapped to:
-        #### Ok(Some(_)) and Err(_).
+        - `Null()` → `Ok(Null())`
+        - `Some(Ok(v))` → `Ok(Some(v))`
+        - `Some(Err(e))` → `Err(e)`
+        - `Some(non-Result value)` → raises `TransposeError` (no silent fallback)
+
+        # Raises
+            `TransposeError` if a `Some` holds a value that is not a `Result`.
 
         # Examples:
 
         >>> msg = "Something went wrong"
-        >>> no_result = "No result"
         >>> assert Some(Result.Ok("foo")).transpose() == Result.Ok(Some("foo"))
         >>> assert Some(Result.Err(msg)).transpose() == Result.Err(msg)
         >>> assert Null().transpose() == Result.Ok(Null())
-        >>> assert Some(no_result).transpose() == Result.Ok(Some(no_result))
+        >>> with pytest.raises(TransposeError):
+        ...     Some("No result").transpose()
         """
 
     @abc.abstractmethod
@@ -400,8 +406,8 @@ class Option[T](abc.ABC):
         If `self` is `Some((a, b))`, returns `(Some(a), Some(b))`.
         If `self` is `Null()`, returns `(Null(), Null())`.
 
-        Invariante: Ist eine Tupelkomponente `None`, wirft `Some(None)` beim
-        Konstruieren `ValueError` — der Guard in `Some.__init__` greift auch hier.
+        Invariant: if a tuple component is `None`, constructing `Some(None)`
+        raises `ValueError` — the guard in `Some.__init__` applies here too.
 
         # Examples:
 
@@ -500,16 +506,17 @@ class Some[T](Option[T]):
         return Ok(self._value)
 
     def transpose[E](self) -> Result[Option[T], E]:
-        # ponytail: deferred import — see ok_or.
-        from .results import Err, Ok
+        # ponytail: deferred import breaks the results<->option cycle.
+        from .results import Result, TransposeError
 
-        match self._value:
-            case Ok(value):
-                return Ok(Some(value))
-            case Err() as err:
-                return err
-            case _:
-                return Ok(self)
+        # ponytail: Result carries the dispatch — Ok(v).map(Some) -> Ok(Some(v)),
+        # Err(e).map(Some) -> Err(e). A non-Result payload is a contract violation.
+        if isinstance(self._value, Result):
+            return self._value.map(Some)
+        raise TransposeError(
+            "Option.transpose expects Option[Result[...]]; "
+            f"Some holds a non-Result value: {self._value!r}"
+        )
 
     def unwrap(self) -> T:
         return self._value

--- a/src/results/results.py
+++ b/src/results/results.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 import abc
 import functools
 from collections.abc import Callable, Iterator
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, cast, final
+from typing import Any, Literal, NoReturn, final
 
-from .option import Null, Some
-
-if TYPE_CHECKING:
-    from .option import Option
+from .option import Null, Option, Some
 
 
 class ResultError(Exception):
@@ -17,6 +14,16 @@ class ResultError(Exception):
 
 class UnwrapFailedError(ResultError):
     """Unwrap failed error."""
+
+
+class TransposeError(ResultError):
+    """Raised by `transpose` when the payload is not the expected wrapped type.
+
+    `Option.transpose` expects `Option[Result[...]]` and `Result.transpose`
+    expects `Result[Option[...]]`. Python cannot enforce that at the type level,
+    so a foreign payload (a `Some`/`Ok` holding a non-`Result`/non-`Option`
+    value) is a programming error — rejected loudly instead of silently wrapped.
+    """
 
 
 class Result[T, E](abc.ABC):
@@ -130,7 +137,7 @@ class Result[T, E](abc.ABC):
         """
 
     @abc.abstractmethod
-    def map_or[U](self, op: Callable[[T], U], default: U) -> U:
+    def map_or[U](self, default: U, op: Callable[[T], U]) -> U:
         """Returns the provided default result (if [`Err`]), or applies a function to the contained value (if [`Ok`])."""
 
     @abc.abstractmethod
@@ -160,10 +167,13 @@ class Result[T, E](abc.ABC):
         - `Ok(Some(v))` → `Some(Ok(v))`
         - `Ok(Null())` → `Null()`
         - `Err(e)` → `Some(Err(e))`
-        - `Ok(non-Option value)` → `Some(self)` (lenient fallback)
+        - `Ok(non-Option value)` → raises `TransposeError` (no silent fallback)
 
         This is the mirror image of [`Option.transpose`], and the two are inverses:
         `Some(Ok(v)).transpose().transpose() == Some(Ok(v))`.
+
+        # Raises
+            `TransposeError` if an `Ok` holds a value that is not an `Option`.
         """
 
     @abc.abstractmethod
@@ -246,11 +256,11 @@ class Ok[T](Result[T, Any]):
     def map[U, E](self, fn: Callable[[T], U]) -> Result[U, E]:
         return Ok(fn(self._inner_value))
 
-    def map_err[U, E, F](self, fn: Callable[[E], F]) -> Result[U, F]:
-        return Ok(cast(U, self._inner_value))
+    def map_err[E, F](self, fn: Callable[[E], F]) -> Result[T, F]:
+        return Ok(self._inner_value)
 
-    def map_or[U](self, fn: Callable[[T], U], default_value: U) -> U:
-        return fn(self._inner_value)
+    def map_or[U](self, default: U, op: Callable[[T], U]) -> U:
+        return op(self._inner_value)
 
     def map_or_else[U, E](
         self,
@@ -269,15 +279,14 @@ class Ok[T](Result[T, Any]):
         return Ok(self._inner_value)
 
     def transpose[U, E](self) -> Option[Result[U, E]]:
-        match self._inner_value:
-            case Some(value):
-                return Some(Ok(value))
-            case Null():
-                return Null()
-            case _:
-                return Some(
-                    cast(Result[U, E], self)
-                )  # ponytail: lenient fallback — non-Option payload
+        # ponytail: Option carries the dispatch — Some(v).map(Ok) -> Some(Ok(v)),
+        # Null().map(Ok) -> Null(). A non-Option payload is a contract violation.
+        if isinstance(self._inner_value, Option):
+            return self._inner_value.map(Ok)
+        raise TransposeError(
+            "Result.transpose expects Result[Option[...]]; "
+            f"Ok holds a non-Option value: {self._inner_value!r}"
+        )
 
     def unwrap(self) -> T:
         return self._inner_value
@@ -355,8 +364,8 @@ class Err[E](Result[Any, E]):
     def map_err[U, F](self, fn: Callable[[E], F]) -> Result[U, F]:
         return Err(fn(self._inner_value))
 
-    def map_or[T, U](self, fn: Callable[[T], U], default_value: U) -> U:
-        return default_value
+    def map_or[T, U](self, default: U, op: Callable[[T], U]) -> U:
+        return default
 
     def map_or_else[T, U](
         self,

--- a/tests/results/test_option.py
+++ b/tests/results/test_option.py
@@ -4,7 +4,7 @@ import re
 
 import pytest
 
-from results import Err, Null, Ok, Option, Some, UnwrapFailedError
+from results import Err, Null, Ok, Option, Some, TransposeError, UnwrapFailedError
 
 
 @Option.as_option
@@ -603,17 +603,22 @@ def test_or_else_when_some_should_return_some(option, func, expected):
         (Some(Ok(5)), Ok(Some(5))),
         (Some(Err("error")), Err("error")),
         (Null(), Ok(Null())),
-        (Some(5), Ok(Some(5))),
     ],
     ids=[
         "transpose_when_some_ok_should_return_ok_with_some_value",
         "transpose_when_some_err_should_return_err",
         "transpose_when_null_should_return_ok_with_null",
-        "transpose_when_some_value_should_return_ok_some_value",
     ],
 )
 def test_transpose_with_result(option, expected):
     assert option.transpose() == expected
+
+
+def test_transpose_on_non_result_payload_raises() -> None:
+    # Option.transpose expects Option[Result[...]]; a Some holding a non-Result
+    # value is a contract violation — raise loudly, never silently wrap.
+    with pytest.raises(TransposeError, match="non-Result"):
+        Some(5).transpose()
 
 
 @pytest.mark.parametrize(
@@ -644,22 +649,18 @@ def test_flatten_some_returns_inner_option_identity() -> None:
     assert Some(inner_null).flatten() is inner_null
 
 
-@pytest.mark.parametrize(
-    "removed_name",
-    [
-        "OptionError",
-        "TransposeError",
-    ],
-    ids=[
-        "option_error_is_removed_from_public_api",
-        "transpose_error_is_removed_from_public_api",
-    ],
-)
-def test_dead_option_error_hierarchy_is_no_longer_exported(removed_name):
+def test_option_error_is_no_longer_exported() -> None:
     import results
 
-    assert not hasattr(results, removed_name)
-    assert removed_name not in results.__all__
+    assert not hasattr(results, "OptionError")
+    assert "OptionError" not in results.__all__
+
+
+def test_transpose_error_is_exported() -> None:
+    import results
+
+    assert results.TransposeError is TransposeError
+    assert "TransposeError" in results.__all__
 
 
 @pytest.mark.parametrize(

--- a/tests/results/test_public_api.py
+++ b/tests/results/test_public_api.py
@@ -19,6 +19,7 @@ PUBLIC_NAMES = [
     "Result",
     "ResultError",
     "Some",
+    "TransposeError",
     "UnwrapFailedError",
 ]
 
@@ -38,7 +39,7 @@ def test_public_all_has_no_drift() -> None:
     [
         (
             "results.results",
-            {"Result", "Ok", "Err", "ResultError", "UnwrapFailedError"},
+            {"Result", "Ok", "Err", "ResultError", "TransposeError", "UnwrapFailedError"},
         ),
         ("results.option", {"Option", "Some", "Null"}),
     ],

--- a/tests/results/test_result.py
+++ b/tests/results/test_result.py
@@ -2,7 +2,7 @@ import re
 
 import pytest
 
-from results import Err, Null, Ok, Result, Some, UnwrapFailedError
+from results import Err, Null, Ok, Result, Some, TransposeError, UnwrapFailedError
 
 
 def get_test_error():
@@ -179,7 +179,7 @@ def test_map(input, func, expected):
     ],
 )
 def test_map_or(result, func, default, expected):
-    assert result.map_or(func, default) == expected
+    assert result.map_or(default, func) == expected
 
 
 @pytest.mark.parametrize(
@@ -576,17 +576,22 @@ def test_and_or_identity() -> None:
         (Ok(Some(42)), Some(Ok(42))),
         (Ok(Null()), Null()),
         (Err("e"), Some(Err("e"))),
-        (Ok(99), Some(Ok(99))),
     ],
     ids=[
         "transpose Ok(Some(v)) -> Some(Ok(v))",
         "transpose Ok(Null()) -> Null()",
         "transpose Err(e) -> Some(Err(e))",
-        "transpose Ok(non-option fallback) -> Some(self)",
     ],
 )
 def test_transpose(result, expected):
     assert result.transpose() == expected
+
+
+def test_transpose_on_non_option_payload_raises() -> None:
+    # Result.transpose expects Result[Option[...]]; an Ok holding a non-Option
+    # value is a contract violation — raise loudly, never silently wrap.
+    with pytest.raises(TransposeError, match="non-Option"):
+        Ok(99).transpose()
 
 
 def test_transpose_round_trip() -> None:


### PR DESCRIPTION
Code-quality review of the recent `Option`/`Result` additions. Two **breaking** changes plus small cleanups. All 215 tests pass; `mypy`/`ruff` clean.

## `transpose` — raise instead of silent fallback (BREAKING)
- `Option.transpose` / `Result.transpose` now **raise `TransposeError`** (re-introduced as a `ResultError` subclass, exported) when the payload is not the expected `Result`/`Option` wrapper — a contract violation, no longer silently wrapped as `Ok(self)` / `Some(self)`.
- Both implementations now **delegate to the dual family's `.map`** (`Ok(v).map(Some)`, `Some(v).map(Ok)`) instead of pattern-matching the inner variant. The 3-arm `match` collapses to one polymorphic call + a single `isinstance` guard, aligning with the project's "dispatch by polymorphism, not variant-match in a method" rule.
- The `Some(None)` construction guard is unchanged: `Some(Ok(None)).transpose()` still raises `ValueError`.

This reverses the lenient-fallback decision (ADR issue-5 / issue-16) — recorded in [docs/decisions/transpose-raises-on-foreign-payload.md](docs/decisions/transpose-raises-on-foreign-payload.md). Rationale: the lenient fallback itself deviated from Rust (which type-constrains `transpose`), and Python can't enforce that, so a loud runtime guard is the honest boundary.

## `Result.map_or` — argument order (BREAKING)
- `(op, default)` → `(default, op)`, matching `Option.map_or`, `Result.map_or_else`, and Rust. It was the lone outlier (even against its own `*_else`).
- **Migration:** `result.map_or(f, default)` → `result.map_or(default, f)`.
- Recorded in [docs/decisions/map-or-argument-order.md](docs/decisions/map-or-argument-order.md).

## Cleanups
- Drop gratuitous `cast` / phantom `U` in `Ok.map_err`.
- Fix copy-pasted `Option.from_fn` / `as_option` docstrings (they referenced `Result`/`div`/`map_err`).
- Translate the German `unzip` docstring line to English.

## Docs kept in sync
`CONTEXT.md` (transpose entries, error hierarchy, new `TransposeError` entry, relaxed the "transpose wirft nie" invariant), `CLAUDE.md` failure-mode paragraph, and the two decision logs above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)