### PR TITLE
ci: add GitHub Actions workflow (ruff, mypy, pytest) on push/PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Lint (ruff)
+        run: uv run ruff check
+
+      - name: Type-check (mypy)
+        run: uv run mypy src tests
+
+      - name: Test (pytest + coverage)
+        run: uv run pytest --cov=results


### PR DESCRIPTION
## Summary

Implements **Plan 002** — adds the missing CI baseline so "the suite is green" becomes a property of `main`, not a hope.

Adds a single file, `.github/workflows/ci.yml`, with one `check` job that runs the uv-managed gates on push to `main` and on every pull request:

- `uv sync --frozen` (fails if `uv.lock` is stale rather than silently updating)
- `uv run ruff check`
- `uv run mypy src tests`
- `uv run pytest --cov=results`

Python comes from `.python-version` (3.13) via `uv python install`. Least-privilege `permissions: contents: read`; `concurrency` with `cancel-in-progress` to avoid redundant runs. Actions pinned to current major tags (`actions/checkout@v4`, `astral-sh/setup-uv@v5`). No source/config/test changes — CI only.

## Note: `ruff format --check` intentionally deferred

Per the plan, a format gate is **not** added here: at this commit `uv run ruff format --check` would reformat `tests/results/test_public_api.py`, so enforcing it now would make CI red on its first run. Format enforcement is a separate follow-up that must first run `uv run ruff format` and commit the result. A Python version matrix is likewise out of scope.

## Definition of Done

- [x] `.github/workflows/ci.yml` exists and parses as valid YAML (2-space, no tabs, no trailing whitespace)
- [x] References `uv run ruff check`, `uv run mypy src tests`, `uv run pytest --cov=results`; does NOT reference `ruff format`
- [x] `git status --porcelain` lists only `.github/workflows/ci.yml`
- [x] `uv run pytest -q` still passes locally (215 passed)
- [x] All four gate commands confirmed green locally before encoding (ruff clean, mypy clean, 215 passed @ 99% cov, `uv sync --frozen` ok)
- [ ] `plans/README.md` status row for 002 — maintained externally by the orchestrator (not touched here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)