### PR TITLE
fix(option): declare is_some/is_some_and on the Option ABC

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -141,6 +141,24 @@ je eine Implementierung auf `Some` und `Null`); kein `isinstance`- oder
 **neuen** Container zurück; `inspect` gibt `self` zurück und ist für reine
 Nebeneffekte gedacht.
 
+### is_some / is_some_and
+
+Zwei `Option`-Methoden zum **Abfragen der Variante** auf der Vorhanden-Seite —
+das Spiegelbild von `is_ok` / `is_ok_and` auf `Result`:
+
+- `is_some()` — `True`, wenn die Option `Some` ist, sonst `False`.
+- `is_some_and(op)` — `True`, wenn die Option `Some(v)` ist **und** `op(v)`
+  wahr ergibt; bei `Null` immer `False` (das Prädikat wird nicht aufgerufen).
+  Komplement zu `is_none_or`.
+
+Beide sind `@abc.abstractmethod` auf `Option` und je einmal auf `Some` und
+`Null` implementiert (polymorpher Dispatch, kein `isinstance`/Flag-Check). Sie
+gehören zur abstrakten `Option`-Oberfläche — über eine `Option[T]`-Referenz
+typgeprüft aufrufbar.
+
+*Avoid:* annehmen, `is_some_and` werte `op` auch bei `Null` aus. Tut es nicht —
+`Null.is_some_and` gibt `False` zurück, ohne `op` zu berühren.
+
 ### and_ / xor
 
 Zwei `Option`-Methoden für **kombinatorische** Verknüpfung zweier Options:

--- a/docs/decisions/option-is-some-on-abc.md
+++ b/docs/decisions/option-is-some-on-abc.md
@@ -1,0 +1,79 @@
+# Entscheidungs-Log — Plan 001 (Option: `is_some` / `is_some_and` auf der ABC)
+
+Vollautonomer Modus. Offene/mehrdeutige Punkte gemäß Entscheidungsreihenfolge gelöst:
+
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Option`-Semantik (std) · 4. ponytail-Default.
+
+Scope: ausschließlich `src/results/option.py`, `tests/results/test_option.py`,
+`CONTEXT.md` (Anker `### is_none_or / inspect`) und dieser Log. Kein
+`results.py`-Diff, keine Änderung an den konkreten `Some`/`Null`-Implementierungen.
+
+## E1 — Diagnose: Asymmetrie-Bug, keine Verhaltensänderung
+
+- **Offener Punkt:** Was genau ist defekt?
+- **Entscheidung:** `is_some` / `is_some_and` existieren konkret auf `Some` und
+  `Null`, sind aber **nicht** als `@abc.abstractmethod` auf `Option` deklariert.
+  Über eine `Option[T]`-Referenz (der Normalfall — Rückgabetyp von `map`,
+  `filter`, `and_then`, `from_fn`, …) meldet mypy `attr-defined`. Die Schwester
+  `Result` deklariert `is_ok` / `is_ok_and` auf ihrer Basis; `Option` zog nicht
+  nach.
+- **Begründung:** (1)/(2) Die Invariante „jede `Option`-Methode ist abstrakt auf
+  der Basis plus je eine Implementierung auf `Some` und `Null`" war für dieses
+  Paar verletzt. Der Fix ist rein additiv — Laufzeitverhalten bleibt identisch.
+
+## E2 — Nur zwei abstrakte Stubs hinzufügen (ponytail)
+
+- **Offener Punkt:** Wie minimal lässt sich der Bug beheben?
+- **Entscheidung:** Genau zwei `@abc.abstractmethod`-Stubs auf `Option`. Die
+  konkreten Implementierungen auf `Some`/`Null` sind bereits korrekt und werden
+  **nicht** angefasst.
+- **Begründung:** (4) ponytail — kürzester Diff, der den Typfehler schließt.
+  Mehr Code wäre Scope-Creep.
+- **Verworfen:** `is_some` über `not self.is_none()` auf der Basis
+  default-implementieren. Das bräche das Polymorphie-Muster (Verhalten käme aus
+  einer Default-Methode statt aus den Varianten) und widerspräche `CLAUDE.md`.
+
+## E3 — Parametername `op`, nicht `fn`
+
+- **Offener Punkt:** Welcher Parametername für den abstrakten `is_some_and`-Stub?
+- **Entscheidung:** `op` — exakt wie die bestehenden konkreten Signaturen auf
+  `Some`/`Null`. (`is_none_or` nutzt `fn`; das Prädikat-Argument von `is_some_and`
+  heißt im Bestand `op`.)
+- **Begründung:** (2) Signatur-Parität zwischen Basis und Implementierungen;
+  divergierende Namen brächen die LSP-Übereinstimmung optisch und sind irritierend.
+- **Verworfen:** `fn` (würde von den konkreten Implementierungen abweichen).
+
+## E4 — Rückgabetyp `bool` auf der Basis
+
+- **Offener Punkt:** `bool` oder `Literal[...]` auf den abstrakten Stubs?
+- **Entscheidung:** `bool`. Die varianten-spezifischen `Literal[True]` /
+  `Literal[False]` bleiben auf `Some`/`Null`; die Basis nennt den gemeinsamen
+  Obertyp.
+- **Begründung:** (2) Spiegelt `is_none` / `is_none_or` auf der Basis (beide
+  `-> bool`), während die Literals auf der konkreten Ebene erhalten bleiben.
+
+## E5 — Methoden-Platzierung: `is_none` → `is_none_or` → `is_some` → `is_some_and`
+
+- **Offener Punkt:** Wo auf der Basis einfügen?
+- **Entscheidung:** Direkt nach `is_none_or`, vor `map` — entsprechend der in
+  `docs/decisions/issue-17-option-is-none-or-inspect.md:16-17` dokumentierten
+  Reihenfolge.
+- **Begründung:** (1)/(2) Bestehende, dokumentierte Ordnungs-Konvention.
+
+## E6 — TDD: roter Typ-Check vor der Implementierung
+
+- **Vorgehen:** `test_is_some_and_is_some_and_callable_through_option_base` ruft
+  beide Methoden über eine `Option[int]`-Referenz auf. Zuerst hinzugefügt: vier
+  rote `attr-defined`-Fehler in mypy bestätigt (der eigentliche Gate), dann die
+  Stubs ergänzt — mypy grün, Suite grün. Die bestehenden parametrisierten
+  `is_some_*`-Tabellen decken das Laufzeitverhalten unverändert ab.
+
+## E7 — CONTEXT.md: neuer Abschnitt `### is_some / is_some_and`
+
+- **Offener Punkt:** Wo in CONTEXT.md einfügen?
+- **Entscheidung:** Unmittelbar nach `### is_none_or / inspect`, vor
+  `### and_ / xor`. Kein anderer Abschnitt berührt.
+- **Begründung:** (1) `CLAUDE.md` verlangt CONTEXT.md-Pflege bei Vertrags-
+  änderungen an öffentlichen Methoden; der Abschnitt steht thematisch neben
+  seinem Komplement `is_none_or`.

--- a/src/results/option.py
+++ b/src/results/option.py
@@ -207,6 +207,30 @@ class Option[T](abc.ABC):
         """
 
     @abc.abstractmethod
+    def is_some(self) -> bool:
+        """
+        Returns `true` if the option is a [`Some`] value.
+
+        # Examples:
+
+        >>> assert Some(10).is_some()
+        >>> assert not Null().is_some()
+        """
+
+    @abc.abstractmethod
+    def is_some_and(self, op: Callable[[T], bool]) -> bool:
+        """
+        Returns `true` if the option is [`Some`] and the value inside matches
+        the predicate `op`. The complement of `is_none_or`.
+
+        # Examples:
+
+        >>> assert Some(10).is_some_and(is_even)
+        >>> assert not Some(15).is_some_and(is_even)
+        >>> assert not Null().is_some_and(is_even)
+        """
+
+    @abc.abstractmethod
     def map[U](self, op: Callable[[T], U]) -> Option[U]:
         """
         Maps an `Option<T>` to `Option<U>` by applying a function to a contained value

--- a/tests/results/test_option.py
+++ b/tests/results/test_option.py
@@ -203,6 +203,19 @@ def test_is_none_or_when_null_returns_true_and_some_defers_to_predicate(
     assert option.is_none_or(predicate) == expected
 
 
+def test_is_some_and_is_some_and_callable_through_option_base() -> None:
+    # Regression for the typed interface: is_some / is_some_and must be
+    # reachable through an Option[T] reference (declared on the ABC), not only
+    # on the concrete Some / Null. This guards against them silently slipping
+    # off the base again — `uv run mypy src tests` is the real gate here.
+    present: Option[int] = Some(10)
+    absent: Option[int] = Null()
+    assert present.is_some()
+    assert not absent.is_some()
+    assert present.is_some_and(lambda v: v > 5)
+    assert not absent.is_some_and(lambda v: v > 5)
+
+
 def test_inspect_runs_fn_only_on_some_and_returns_self() -> None:
     calls: list[int] = []
     fn = lambda v: calls.append(v)  # noqa: E731


### PR DESCRIPTION
## Summary

`Some` and `Null` both implement `is_some()` / `is_some_and(...)`, but the two methods were **not declared on the `Option` abstract base**. Any value typed `Option[T]` (the normal case — the return type of `map`, `filter`, `and_then`, `from_fn`, …) got a static `attr-defined` error when calling them. The sibling `Result` family already declares `is_ok` / `is_ok_and` on its base; `Option` now matches.

The fix is purely additive: two `@abc.abstractmethod` stubs on the `Option` base (concrete implementations on `Some`/`Null` unchanged), a type-checked regression test, a CONTEXT.md glossary entry, and a decision log. Implements `docs/plans/001-option-is-some-on-abc.md`.

## Definition of Done

- [x] `uv run mypy src tests` → `Success: no issues found in 9 source files`
- [x] `uv run pytest -q` → `216 passed` (215 existing + 1 new regression test)
- [x] `uv run ruff check` → `All checks passed!`
- [x] `uv run ruff format` → 2 files left unchanged
- [x] `grep "def is_some"` → 3 matches; `grep "def is_some_and"` → 3 matches (base abstract + `Some` + `Null`)
- [x] CONTEXT.md updated with `### is_some / is_some_and` entry
- [x] Working tree clean — only in-scope files changed (`src/results/option.py`, `tests/results/test_option.py`, `CONTEXT.md`, `docs/decisions/option-is-some-on-abc.md`)
- [x] Decision log added (ADR)
- [x] plans/README.md index row — maintained externally by the orchestrator

## Approach

- **TDD**: added the regression test first (confirmed 4 red `attr-defined` mypy errors through an `Option[int]` reference), then added the stubs (green).
- **ponytail**: smallest diff that closes the type hole; no default impl on the base (would break the polymorphism invariant `CLAUDE.md` mandates).
- **thermo-nuclear review**: 1 iteration, fixpoint reached — no structural findings; the change reinforces the existing "abstract on base + impl per variant" invariant rather than eroding it.

## ADR

[docs/decisions/option-is-some-on-abc.md](docs/decisions/option-is-some-on-abc.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)