### PR TITLE
refactor(option)!: remove Option.some/none pass-through constructors

### DIFF
--- a/docs/decisions/remove-option-some-none.md
+++ b/docs/decisions/remove-option-some-none.md
@@ -1,0 +1,43 @@
+# Entscheidungs-Log — `Option.some()` / `Option.none()` entfernen
+
+Kehrt die Festlegung aus
+[issue-7-seal-option-two-state.md](issue-7-seal-option-two-state.md) §E2
+(„`Option.some()` / `Option.none()` Classmethods behalten") um. Offene Punkte
+autonom gemäß Entscheidungsreihenfolge gelöst: 1. Projekt-Domäne
+(`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen · 3. Rust-`Option`-Semantik ·
+4. ponytail-Default.
+
+## E1 — `some`/`none` ersatzlos entfernen
+
+- **Offener Punkt:** Die beiden Classmethods sind dünne Delegatoren
+  (`some(v) -> Some(v)`, `none() -> Null()`). Behalten (issue-7 §E2) oder
+  entfernen?
+- **Entscheidung:** Entfernen. Die kanonischen Konstruktoren sind `Some(...)`
+  und `Null()`. Ein Konzept, ein Name.
+- **Begründung:** (4) ponytail/Deletionstest: löscht man beide, taucht die
+  Komplexität nicht wieder auf — Aufrufer schreiben `Some(v)`/`Null()`, die sie
+  ohnehin importieren. (2) Symmetrie: die `Result`-Familie hat keine analogen
+  Konstruktor-Classmethods; `Result.ok()`/`err()` sind Konversionen nach
+  `Option`, keine Konstruktoren. (1) `CONTEXT.md` führt `some`/`none` nirgends.
+- **Verworfen:** Behalten + dokumentieren (hält die zweite Vokabel am Leben);
+  `Result.some`/`none` ergänzen (kollidiert mit `Result.ok()`/`err()`, mehr
+  Oberfläche statt weniger).
+
+## E2 — Warum issue-7 §E2 jetzt umgekehrt wird
+
+- **Offener Punkt:** §E2 verwarf das Entfernen ausdrücklich.
+- **Entscheidung:** Die §E2-Begründung war eng auf den Issue-#7-Scope bezogen
+  („unnötiger zweiter Breaking Change" *innerhalb von #7*), kein dauerhafter
+  semantischer Einwand. Als eigenständiger, gewollter `refactor!` ist das genau
+  der aufgeschobene Bruch — vor 1.0 (`0.1.0`) ist er günstig.
+- **Begründung:** Konvention: API-/Semantik-Brüche werden dokumentiert; diese
+  ADR ist der Datensatz.
+
+## E3 — Breaking Change kennzeichnen & Test anpassen
+
+- **Entscheidung:** Im PR-Body als Breaking Change vermerken. Der einzige
+  Verweis im Testcode (`Option.some(None)` in `test_some_none_is_forbidden`)
+  entfällt; die übrigen `Some(None)`-Pfade (direkt, via `map`, via `transpose`)
+  bleiben und decken den `Some.__init__`-Guard weiterhin ab.
+- **Begründung:** Tests decken den Konstruktor-Guard, nicht eine entfernte
+  Methode.

--- a/src/results/option.py
+++ b/src/results/option.py
@@ -63,26 +63,6 @@ class Option[T](abc.ABC):
 
         return inner
 
-    @classmethod
-    def some(cls, content: T) -> Option[T]:
-        """
-        Creates an `Option` instance that contains `Some` value.
-
-        Examples:
-        >>> assert Option.some(10) == Some(10)
-        """
-        return Some(content)
-
-    @classmethod
-    def none(cls) -> Option[T]:
-        """
-        Creates an `Option` instance that contains a `Null` value.
-
-        Examples:
-        >>> assert Option.none() == Null()
-        """
-        return Null()
-
     @abc.abstractmethod
     def and_[U](self, optb: Option[U]) -> Option[U]:
         """Returns [`Null`] if the option is [`Null`], otherwise returns `optb`.

--- a/tests/results/test_option.py
+++ b/tests/results/test_option.py
@@ -433,8 +433,6 @@ def test_some_none_is_forbidden() -> None:
     with pytest.raises(ValueError, match="Some.None. is forbidden"):
         Some(None)
     with pytest.raises(ValueError, match="Some.None. is forbidden"):
-        Option.some(None)
-    with pytest.raises(ValueError, match="Some.None. is forbidden"):
         Some(5).map(lambda _: None)
     with pytest.raises(ValueError, match="Some.None. is forbidden"):
         Some(Ok(None)).transpose()


### PR DESCRIPTION
## What

Removes the two `Option` pass-through classmethods `Option.some(v)` (returned `Some(v)`) and `Option.none()` (returned `Null()`). They duplicated the canonical constructors `Some(...)` / `Null()`, gave one construction concept a second vocabulary, were absent from `CONTEXT.md`, and had no mirror in the `Result` family (which has no constructor classmethods — `Result.ok()`/`err()` are conversions to `Option`). One concept, one name.

Implements plan `docs/plans/004-remove-option-some-none.md`.

## Diff

Three in-scope files:
- `src/results/option.py` — deleted the `some` and `none` classmethods (-20 lines), including their doctest examples. The `Option` ABC's polymorphic-dispatch design and the `Some.__init__` `None`-guard are untouched.
- `tests/results/test_option.py` — removed the single now-dead assertion `Option.some(None)` from `test_some_none_is_forbidden`. The three surviving paths (`Some(None)` direct, via `map`, via `transpose`) still cover the constructor's `None`-guard.
- `docs/decisions/remove-option-some-none.md` (new) — superseding ADR that reverses `issue-7-seal-option-two-state.md` §E2's deferral. §E2's objection was scope-bound ("no second breaking change within issue #7"), not semantic; pre-1.0 (`0.1.0`) is the cheap moment for the intentional break.

## BREAKING CHANGE

`Option.some()` and `Option.none()` are removed. Callers use `Some(...)` and `Null()` instead. Verified there were no callers in `src/`/`tests/` beyond the one dead test assertion.

## Gates

- `uv run pytest -q` → 216 passed
- `uv run mypy src tests` → Success: no issues found in 9 source files
- `uv run ruff check` → All checks passed!
- `uv run ruff format` → applied (no changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)