### PR TITLE
feat(result): add flatten — collapse one level of Result nesting

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -345,6 +345,18 @@ Beide Implementierungen sind polymorphisch (`@abc.abstractmethod` auf `Option`,
 je eine Implementierung auf `Some` und `Null`); kein `isinstance`-, `is None`-
 oder Truthiness-Check im Körper.
 
+**`Result.flatten`** spiegelt das auf die `Result`-Seite — kollabiert
+`Result[Result[T, E], E]` zu `Result[T, E]`:
+
+- `Ok(Ok(v))`  → `Ok(v)`
+- `Ok(Err(e))` → `Err(e)`
+- `Err(e)`     → `Err(e)`
+
+`Ok.flatten` gibt das innere `Result` direkt zurück (Identität:
+`Ok(inner).flatten() is inner`); `Err.flatten` reicht sich selbst durch (`return
+self`), wie `Err.map`. Keine `None`-Behandlung — `Result` erlaubt `None` als
+Wert; das `Some(None)`-Risiko der `Option`-Seite existiert hier nicht.
+
 *Avoid:* `flatten` mit `map` oder `and_then` verwechseln. `map(f)` transformiert
 den Inhalt und verpackt ihn neu; `and_then(f)` wendet eine Funktion an, die
 selbst ein `Option` zurückgibt. `flatten` nimmt keine Funktion — es setzt nur

--- a/docs/decisions/result-flatten.md
+++ b/docs/decisions/result-flatten.md
@@ -1,0 +1,36 @@
+# Entscheidungs-Log — `Result`: `flatten`
+
+Spiegelt [issue-20-option-flatten.md](issue-20-option-flatten.md) auf die
+`Result`-Seite. Offene Punkte autonom gemäß Entscheidungsreihenfolge gelöst:
+1. Projekt-Domäne (`CONTEXT.md`, `CLAUDE.md`) · 2. Code-Konventionen ·
+3. Rust-`Result`-Semantik (std) · 4. ponytail-Default.
+
+## E1 — `Ok.flatten` gibt das innere `Result` direkt zurück (Identität)
+
+- **Entscheidung:** `return self._value` — kein neues `Ok`/`Err`.
+  `self._value` ist bereits ein `Result[U, E]`, also das korrekte
+  Ergebnis für `Ok(Ok(v))` (→ `Ok(v)`) und `Ok(Err(e))` (→ `Err(e)`).
+- **Begründung:** (3) Rust: `Result::flatten` ≙ `and_then(|x| x)`. (4) ponytail:
+  O(1), kein neues Objekt; Identität `Ok(inner).flatten() is inner`.
+
+## E2 — `Err.flatten` reicht sich selbst durch
+
+- **Entscheidung:** `return self` — wie `Err.map`/`Err.and_then`: der Fehler
+  propagiert unverändert (`Err(e)` → `Err(e)`).
+
+## E3 — Self-Typ-Signatur mit PEP 695, kein Laufzeit-Check
+
+- **Entscheidung:**
+  - ABC: `def flatten[U](self: Result[Result[U, E], E]) -> Result[U, E]`
+  - `Ok`: `def flatten[U, E](self: Ok[Result[U, E]]) -> Result[U, E]`
+  - `Err`: `def flatten[U](self) -> Result[U, E]`
+- **Begründung:** (2) konsistent mit `Option.flatten`/`transpose`/`unzip`. Der
+  Self-Typ macht `flatten` statisch nur auf verschachtelten `Result`s aufrufbar —
+  kein `isinstance`, kein `TransposeError`-artiger Laufzeit-Check nötig (anders
+  als `transpose`, dessen Vertragsbruch nicht über den Self-Typ ausdrückbar ist).
+
+## E4 — TDD & Doku
+
+- **Vorgehen:** Tests zuerst (rot: `AttributeError: ... has no attribute
+  'flatten'`), dann Implementierung (grün). `CONTEXT.md`-Abschnitt `### flatten`
+  um die `Result`-Seite ergänzt.

--- a/src/results/results.py
+++ b/src/results/results.py
@@ -97,6 +97,28 @@ class Result[T, E](abc.ABC):
         """
 
     @abc.abstractmethod
+    def flatten[U](self: Result[Result[U, E], E]) -> Result[U, E]:
+        """Collapses one level of `Result` nesting.
+
+        Mappings:
+
+        - `Ok(Ok(v))`  → `Ok(v)`
+        - `Ok(Err(e))` → `Err(e)`
+        - `Err(e)`     → `Err(e)`
+
+        This is the named form of `and_then(lambda x: x)` (identity flatmap) and
+        the `Result` mirror of [`Option.flatten`]. `Ok.flatten` returns the
+        stored inner `Result` unchanged — an identity operation
+        (`Ok(inner).flatten() is inner`), never re-wraps.
+
+        # Examples:
+
+        >>> assert Ok(Ok(5)).flatten() == Ok(5)
+        >>> assert Ok(Err("e")).flatten() == Err("e")
+        >>> assert Err("e").flatten() == Err("e")
+        """
+
+    @abc.abstractmethod
     def is_err(self) -> bool:
         """Returns `True` if the result is an [`Err`] value."""
 
@@ -234,6 +256,11 @@ class Ok[T](Result[T, Any]):
     def expect_err(self, msg: str) -> NoReturn:
         raise UnwrapFailedError(msg)
 
+    def flatten[U, E](self: Ok[Result[U, E]]) -> Result[U, E]:
+        # ponytail: self._value is already a Result[U, E] — return it
+        # directly. No re-wrap, O(1). Identity: Ok(inner).flatten() is inner.
+        return self._value
+
     def is_err(self) -> Literal[False]:
         return False
 
@@ -338,6 +365,10 @@ class Err[E](Result[Any, E]):
 
     def expect_err(self, msg: str) -> E:
         return self._value
+
+    def flatten[U](self) -> Result[U, E]:
+        # ponytail: Err propagates unchanged — same shape as Err.map.
+        return self
 
     def is_err(self) -> Literal[True]:
         return True

--- a/tests/results/test_result.py
+++ b/tests/results/test_result.py
@@ -607,3 +607,29 @@ def test_transpose_round_trip() -> None:
     # Null().transpose().transpose() == Null()
     null: Null[Result[int, str]] = Null()
     assert null.transpose().transpose() == null
+
+
+@pytest.mark.parametrize(
+    "result, expected",
+    [
+        (Ok(Ok(5)), Ok(5)),
+        (Ok(Err("e")), Err("e")),
+        (Err("e"), Err("e")),
+    ],
+    ids=[
+        "flatten Ok(Ok(v)) -> Ok(v)",
+        "flatten Ok(Err(e)) -> Err(e)",
+        "flatten Err(e) -> Err(e)",
+    ],
+)
+def test_flatten(result, expected):
+    assert result.flatten() == expected
+
+
+def test_flatten_ok_returns_inner_result_identity() -> None:
+    # Ok.flatten must return the inner Result unchanged — not a re-wrapped copy.
+    inner_ok: Result[int, str] = Ok(5)
+    assert Ok(inner_ok).flatten() is inner_ok
+
+    inner_err: Result[int, str] = Err("e")
+    assert Ok(inner_err).flatten() is inner_err


### PR DESCRIPTION
## Summary

Adds `Result.flatten`, mirroring the existing `Option.flatten` (plan 005). Collapses one level of `Result` nesting `Result[Result[T, E], E]` → `Result[T, E]`:

- `Ok(Ok(v))`  → `Ok(v)`
- `Ok(Err(e))` → `Err(e)`
- `Err(e)`     → `Err(e)`

Implemented the project way: an `@abc.abstractmethod` on the `Result` base plus one implementation each on `Ok` and `Err` (polymorphism, no `isinstance`). `Ok.flatten` returns the stored inner `Result` by identity (`Ok(inner).flatten() is inner`) — no re-wrap, O(1); `Err.flatten` returns `self`, like `Err.map`. Self-type PEP-695 signatures gate `flatten` statically to nested `Result`s, so no runtime `isinstance`/`None` check is needed (unlike `transpose`).

## Changes (in-scope only)

- `src/results/results.py` — abstract `flatten` + `Ok`/`Err` implementations (uses `self._value`, post the `_inner_value`→`_value` rename).
- `tests/results/test_result.py` — parametrized `test_flatten` (3 mappings) + `test_flatten_ok_returns_inner_result_identity` (pins `is`-identity for inner `Ok` and inner `Err`).
- `CONTEXT.md` — `### flatten` section extended with the `Result` side.
- `docs/decisions/result-flatten.md` — new decision log (mirrors issue-20).

## Approach

TDD: tests added first and confirmed red (`AttributeError: ... has no attribute 'flatten'`), then implemented to green.

## Gates

- `uv run pytest -q` → 220 passed (existing + 4 new flatten cases)
- `uv run mypy src tests` → Success: no issues found in 9 source files
- `uv run ruff check` → All checks passed!
- `uv run ruff format` → applied (no changes needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)