### PR TITLE
docs(plans): mark plans 001–005 DONE in the index

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -13,11 +13,11 @@ Repo baseline at planning time: 215 tests pass, coverage 99%, `mypy` clean,
 
 | Plan | Title | Priority | Effort | Risk | Depends on | Status |
 | ----- | ------- | ---------- | -------- | ------ | ------------ | -------- |
-| 001 | `is_some`/`is_some_and` on the `Option` ABC (typing bug) | P1 | S | LOW | — | TODO |
-| 002 | Add GitHub Actions CI (ruff, mypy, pytest) | P1 | S | LOW | — | TODO |
-| 003 | Rename `_inner_value` → `_value` (family symmetry) | P2 | S | LOW | — | TODO |
-| 004 | Remove `Option.some`/`none` pass-throughs (breaking) | P2 | S | MED | — | TODO |
-| 005 | Add `Result.flatten` (parity with `Option.flatten`) | P3 | S | LOW | — | TODO |
+| 001 | `is_some`/`is_some_and` on the `Option` ABC (typing bug) | P1 | S | LOW | — | DONE (#37) |
+| 002 | Add GitHub Actions CI (ruff, mypy, pytest) | P1 | S | LOW | — | DONE (#36) |
+| 003 | Rename `_inner_value` → `_value` (family symmetry) | P2 | S | LOW | — | DONE (#35) |
+| 004 | Remove `Option.some`/`none` pass-throughs (breaking) | P2 | S | MED | — | DONE (#38) |
+| 005 | Add `Result.flatten` (parity with `Option.flatten`) | P3 | S | LOW | — | DONE (#39) |
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (one-line reason) | REJECTED (one-line rationale).
 


### PR DESCRIPTION
Closing single-slice for the `docs/plans/` execution run. All five plans are executed and merged:

| Plan | PR |
| ---- | -- |
| 001 `is_some`/`is_some_and` on the Option ABC | #37 |
| 002 GitHub Actions CI | #36 |
| 003 rename `_inner_value` → `_value` | #35 |
| 004 remove `Option.some`/`none` (breaking) | #38 |
| 005 add `Result.flatten` | #39 |

This PR only flips the status rows in `docs/plans/README.md` from `TODO` to `DONE (#PR)` so the index reflects reality. No source changes.

The local `graphify-out/` graph was regenerated once after all merges (it is gitignored, so it is not part of this or any PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)